### PR TITLE
feat: add CustomKey for a customized signing and verifying

### DIFF
--- a/lib/jwk/index.js
+++ b/lib/jwk/index.js
@@ -1,4 +1,5 @@
 const Key = require('./key/base')
+const CustomKey = require('./key/custom')
 const importKey = require('./import')
 const { generate, generateSync } = require('./generate')
 
@@ -6,6 +7,7 @@ module.exports.asKey = importKey
 module.exports.generate = generate
 module.exports.generateSync = generateSync
 module.exports.isKey = input => input instanceof Key
+module.exports.CustomKey = CustomKey
 
 /* deprecated */
 Object.defineProperty(module.exports, 'importKey', {

--- a/lib/jwk/key/base.js
+++ b/lib/jwk/key/base.js
@@ -14,7 +14,7 @@ const thumbprint = require('../thumbprint')
 const errors = require('../../errors')
 
 class Key {
-  constructor (keyObject, { alg, use, kid, key_ops: ops, x5c, x5t, 'x5t#S256': x5t256 } = {}) {
+  constructor (keyObject, { alg, use, kid, key_ops: ops, x5c, x5t, 'x5t#S256': x5t256, custom } = {}) {
     if (use !== undefined) {
       if (typeof use !== 'string' || !USES.has(use)) {
         throw new TypeError('`use` must be either "sig" or "enc" string when provided')
@@ -76,6 +76,10 @@ class Key {
       })
     }
 
+    if (custom === undefined) {
+      custom = false
+    }
+
     Object.defineProperties(this, {
       [KEYOBJECT]: { value: isObject(keyObject) ? undefined : keyObject },
       type: { value: keyObject.type },
@@ -129,7 +133,8 @@ class Key {
           return this.thumbprint
         },
         configurable: true
-      }
+      },
+      custom: { value: custom }
     })
   }
 

--- a/lib/jwk/key/custom.js
+++ b/lib/jwk/key/custom.js
@@ -1,0 +1,50 @@
+const {
+  JWK_MEMBERS, PUBLIC_MEMBERS, PRIVATE_MEMBERS
+} = require('../../help/consts')
+
+const Key = require('./base')
+
+const CUSTOM_PUBLIC = new Set([])
+Object.freeze(CUSTOM_PUBLIC)
+const CUSTOM_PRIVATE = new Set([...CUSTOM_PUBLIC])
+Object.freeze(CUSTOM_PRIVATE)
+
+class CustomKeyObject {
+  constructor (params) {
+    params = params || {}
+
+    this._type = params.keyType
+    this._symmetricKeySize = params.symmetricKeySize || 0
+  }
+
+  get type () {
+    return this._type
+  }
+
+  get symmetricKeySize () {
+    return this._symmetricKeySize
+  }
+}
+
+// Custom Key Type
+class CustomKey extends Key {
+  constructor (params) {
+    // { alg, use, kid, key_ops: ops, x5c, x5t, 'x5t#S256', keyType, symmetricKeySize } = {}
+    super(new CustomKeyObject(params), Object.assign(params || {}, { custom: true }))
+    this[JWK_MEMBERS]()
+  }
+
+  static get [PUBLIC_MEMBERS] () {
+    return CUSTOM_PUBLIC
+  }
+
+  static get [PRIVATE_MEMBERS] () {
+    return CUSTOM_PRIVATE
+  }
+
+  algorithms (operation, /* second argument is private API */ { use = this.use, alg = this.alg, key_ops: ops = this.key_ops } = {}) {
+    // Should override
+  }
+}
+
+module.exports = CustomKey

--- a/lib/jws/sign.js
+++ b/lib/jws/sign.js
@@ -105,7 +105,12 @@ class Sign {
 
     recipient.header = unprotectedHeader
     recipient.protected = Object.keys(joseHeader.protected).length ? base64url.JSON.encode(joseHeader.protected) : ''
-    recipient.signature = base64url.encodeBuffer(sign(alg, key, Buffer.from(`${recipient.protected}.${i(this).payload}`)))
+
+    if (key.custom) {
+      recipient.signature = base64url.encodeBuffer(key.sign(alg, Buffer.from(`${recipient.protected}.${i(this).payload}`)))
+    } else {
+      recipient.signature = base64url.encodeBuffer(sign(alg, key, Buffer.from(`${recipient.protected}.${i(this).payload}`)))
+    }
   }
 
   /*

--- a/lib/jws/verify.js
+++ b/lib/jws/verify.js
@@ -122,8 +122,14 @@ const jwsVerify = (skipDisjointCheck, serialization, jws, key, { crit = [], comp
 
     check(key, 'verify', alg)
 
-    if (!verify(alg, key, Buffer.from([prot, payload].join('.')), base64url.decodeToBuffer(signature))) {
-      throw new errors.JWSVerificationFailed()
+    if (key.custom) {
+      if (!key.verify(alg, Buffer.from([prot, payload].join('.')), base64url.decodeToBuffer(signature))) {
+        throw new errors.JWSVerificationFailed()
+      }
+    } else {
+      if (!verify(alg, key, Buffer.from([prot, payload].join('.')), base64url.decodeToBuffer(signature))) {
+        throw new errors.JWSVerificationFailed()
+      }
     }
 
     if (!combinedHeader.crit || !combinedHeader.crit.includes('b64') || combinedHeader.b64) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -89,6 +89,8 @@ export namespace JWK {
     x5t?: string;
     'x5t#S256'?: string;
 
+    custom: boolean;
+
     toPEM(private?: boolean, encoding?: pemEncodingOptions): string;
 
     algorithms(operation?: keyOperation): Set<string>;
@@ -142,6 +144,11 @@ export namespace JWK {
     k?: string;
 
     toJWK(private?: boolean): JWKOctKey;
+  }
+
+  class CustomKey extends Key {
+    sign(alg: string, buffer: Buffer): Buffer;
+    verify(alg: string, buffer: Buffer): boolean;
   }
 
   type KeyInput = PrivateKeyInput | PublicKeyInput | string | Buffer;


### PR DESCRIPTION
* Add CustomKey for a customized signing and verifying

* This is can be support JWT signing via KMS like GCP-KMS.

sample code: 
```javascript
const { JWT, JWK, KeyObject } = require('jose')

class CustomKey extends JWK.CustomKey {
  constructor () {
    super({ alg: 'EC', use: 'sig', kid: '12345678', ops: ['sign', 'verify'], keyType: 'private' })
  }

  toPEM (priv, encoding) {
    return undefined
  }

  algorithms (operation) {
    return new Set(['ES256'])
  }

  sign (alg, buffer) {
    console.log('sign invoked: ', alg)
    return 'BASE_64_ENCODED_SIGNATURE'
  }

  verify (alg, buffer) {
    console.log('verify invoked: ', alg)
    return true
  }
}

const customKey = new CustomKey()

const encoded = JWT.sign({}, customKey, {
  expiresIn: '600s'
})

console.log('encoded : ', encoded)

const decoded = JWT.verify(encoded, customKey)

console.log('decoded : ', decoded)

```