### PR TITLE
fix: removes syntax error ("0n" => "0")

### DIFF
--- a/lib/help/key_object.js
+++ b/lib/help/key_object.js
@@ -1,3 +1,5 @@
+/* global BigInt */
+
 const { keyObjectSupported } = require('./runtime_support')
 
 let createPublicKey
@@ -326,7 +328,7 @@ if (keyObjectSupported) {
         const parsed = RSAPublicKey.decode(key, format, { label })
 
         // special case when private pkcs1 PEM / DER is used with createPublicKey
-        if (parsed.n === 0n) {
+        if (parsed.n === BigInt(0)) {
           return createPublicKey(createPrivateKey({ key, format, type, passphrase }))
         }
 

--- a/lib/help/key_utils.js
+++ b/lib/help/key_utils.js
@@ -1,4 +1,5 @@
 /* global BigInt */
+
 const { EOL } = require('os')
 
 const { name: secp256k1 } = require('../jwk/key/secp256k1_crv')


### PR DESCRIPTION
This change removes a syntaxError that was being thrown by babel. The
specific error being thrown was "Identifier directly after number".