### PR TITLE
fix: handle private EC keys without public component

### DIFF
--- a/lib/help/key_utils.js
+++ b/lib/help/key_utils.js
@@ -4,6 +4,7 @@ const { EOL } = require('os')
 
 const errors = require('../errors')
 
+const { keyObjectSupported } = require('./runtime_support')
 const { createPublicKey } = require('./key_object')
 const base64url = require('./base64url')
 const asn1 = require('./asn1')
@@ -89,10 +90,21 @@ const keyObjectToJWK = {
       const ECPrivateKey = asn1.get('ECPrivateKey')
 
       const { privateKey, algorithm: { parameters: { value: crv } } } = PrivateKeyInfo.decode(der)
-      const { privateKey: d, publicKey: { data: publicKey } } = ECPrivateKey.decode(privateKey)
+      const { privateKey: d, publicKey } = ECPrivateKey.decode(privateKey)
 
-      const x = publicKey.slice(1, ((publicKey.length - 1) / 2) + 1)
-      const y = publicKey.slice(((publicKey.length - 1) / 2) + 1)
+      if (typeof publicKey === 'undefined') {
+        if (keyObjectSupported) {
+          return {
+            ...keyObjectToJWK.ec.public(createPublicKey(keyObject)),
+            d: base64url.encodeBuffer(d)
+          }
+        }
+
+        throw new errors.JOSENotSupported('Private EC keys without the public key embedded are not supported in your Node.js runtime version')
+      }
+
+      const x = publicKey.data.slice(1, ((publicKey.data.length - 1) / 2) + 1)
+      const y = publicKey.data.slice(((publicKey.data.length - 1) / 2) + 1)
 
       return {
         kty: 'EC',


### PR DESCRIPTION
Only possible to handle when KeyObject API is available in the runtime.

closes #85