### PR TITLE
Remove logical assignment operators

### DIFF
--- a/src/jwe/flattened/encrypt.ts
+++ b/src/jwe/flattened/encrypt.ts
@@ -263,7 +263,7 @@ export default class FlattenedEncrypt {
       }
     }
 
-    this._iv ||= await generateIv(enc)
+    this._iv || (this._iv = await generateIv(enc))
 
     let additionalData: Uint8Array
     let protectedHeader: Uint8Array

--- a/src/jwk/parse.ts
+++ b/src/jwk/parse.ts
@@ -57,7 +57,7 @@ export default async function parseJwk(
   }
 
   // eslint-disable-next-line no-param-reassign
-  alg ||= jwk.alg
+  alg || (alg = jwk.alg)
 
   if (typeof alg !== 'string' || !alg) {
     throw new TypeError('"alg" argument is required when "jwk.alg" is not present')
@@ -70,7 +70,7 @@ export default async function parseJwk(
       }
 
       // eslint-disable-next-line no-param-reassign, eqeqeq
-      octAsKeyObject ??= jwk.ext !== true
+      octAsKeyObject ?? (octAsKeyObject = jwk.ext !== true)
 
       if (octAsKeyObject) {
         return asKeyObject({ ...jwk, alg, ext: false })

--- a/src/lib/encrypt_key_management.ts
+++ b/src/lib/encrypt_key_management.ts
@@ -45,7 +45,7 @@ async function encryptKeyManagement(
       }
       const { apu, apv } = providedParameters
       let { epk: ephemeralKey } = providedParameters
-      ephemeralKey ||= await ECDH.generateEpk(key)
+      ephemeralKey || (ephemeralKey = await ECDH.generateEpk(key))
       const epk = await ECDH.ephemeralKeyToPublicJWK(ephemeralKey)
       const sharedSecret = await ECDH.deriveKey(
         key,

--- a/src/runtime/browser/aesgcmkw.ts
+++ b/src/runtime/browser/aesgcmkw.ts
@@ -15,7 +15,7 @@ export const wrap: AesGcmKwWrapFunction = async (
 ) => {
   const jweAlgorithm = alg.substr(0, 7)
   // eslint-disable-next-line no-param-reassign
-  iv ||= await generateIv(jweAlgorithm)
+  iv || (iv = await generateIv(jweAlgorithm))
 
   const { ciphertext: encryptedKey, tag } = await encrypt(
     jweAlgorithm,

--- a/src/runtime/node/aesgcmkw.ts
+++ b/src/runtime/node/aesgcmkw.ts
@@ -17,7 +17,7 @@ export const wrap: AesGcmKwWrapFunction = async (
 ) => {
   const jweAlgorithm = alg.substr(0, 7)
   // eslint-disable-next-line no-param-reassign
-  iv ||= await generateIv(jweAlgorithm)
+  iv || (iv = await generateIv(jweAlgorithm))
 
   const { ciphertext: encryptedKey, tag } = await encrypt(
     jweAlgorithm,


### PR DESCRIPTION
[Logical OR assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment#Browser_compatibility) and [logical nullish assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment#Browser_compatibility) are not supported by Node.js.

I translated them to their longform syntax to fix errors of type `SyntaxError: Unexpected token '||='`.