### PR TITLE
Allow `self` to be used as a global object to allow the library to be used in web workers

### DIFF
--- a/src/runtime/browser/base64url.ts
+++ b/src/runtime/browser/base64url.ts
@@ -1,12 +1,13 @@
 import type { Base64UrlDecode, Base64UrlEncode } from '../interfaces.d'
 import { encoder, decoder } from '../../lib/buffer_utils.js'
+import { globals } from '../../util/globals';
 
 export const encode: Base64UrlEncode = (input) => {
   let unencoded = input
   if (typeof unencoded === 'string') {
     unencoded = encoder.encode(unencoded)
   }
-  const base64string = window.btoa(String.fromCharCode.apply(0, [...unencoded]))
+  const base64string = globals.btoa(String.fromCharCode.apply(0, [...unencoded]))
   return base64string.replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
 }
 
@@ -17,7 +18,7 @@ export const decode: Base64UrlDecode = (input) => {
   }
   encoded = encoded.replace(/-/g, '+').replace(/_/g, '/').replace(/\s/g, '')
   return new Uint8Array(
-    window
+    globals
       .atob(encoded)
       .split('')
       .map((c) => c.charCodeAt(0)),

--- a/src/runtime/browser/fetch.ts
+++ b/src/runtime/browser/fetch.ts
@@ -1,5 +1,6 @@
 import type { FetchFunction } from '../interfaces.d'
 import { JOSEError } from '../../util/errors.js'
+import { globals } from '../../util/globals';
 
 const fetch: FetchFunction = async (url: URL, timeout: number) => {
   let controller!: AbortController
@@ -8,7 +9,7 @@ const fetch: FetchFunction = async (url: URL, timeout: number) => {
     setTimeout(() => controller.abort(), timeout)
   }
 
-  const response = await window.fetch(url.href, {
+  const response = await globals.fetch(url.href, {
     signal: controller ? controller.signal : undefined,
     redirect: 'manual',
     referrerPolicy: 'no-referrer',

--- a/src/runtime/browser/webcrypto.ts
+++ b/src/runtime/browser/webcrypto.ts
@@ -1,10 +1,11 @@
 import { JOSEError } from '../../util/errors.js'
+import { globals } from '../../util/globals';
 
-const { crypto } = window
+const { crypto } = globals
 
 export default crypto
 export function ensureSecureContext() {
-  if (!window.isSecureContext && !crypto.subtle) {
+  if (!globals.isSecureContext && !crypto.subtle) {
     throw new JOSEError(
       'Web Cryptography API is available only in Secure Contexts. See: https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts',
     )

--- a/src/util/globals.ts
+++ b/src/util/globals.ts
@@ -1,0 +1,16 @@
+const getGlobal = () => {
+  // eslint-disable-next-line no-restricted-globals
+  if (typeof self !== 'undefined') {
+    // eslint-disable-next-line no-restricted-globals
+    return self
+  }
+  if (typeof window !== 'undefined') {
+    return window
+  }
+  if (typeof global !== 'undefined') {
+    return global
+  }
+  throw new Error('unable to locate global object')
+}
+
+export const globals = getGlobal()

--- a/tsconfig/base.json
+++ b/tsconfig/base.json
@@ -27,7 +27,8 @@
     "../src/util/errors.ts",
     "../src/util/generate_key_pair.ts",
     "../src/util/generate_secret.ts",
-    "../src/util/random.ts"
+    "../src/util/random.ts",
+    "../src/util/globals.ts"
   ],
   "compilerOptions": {
     "strict": true,


### PR DESCRIPTION
Since the 
- `webcrypto.ts`
- `base64url.ts`
- `fetch.ts`
files are using the `window` object, this library cannot be used in web workers. This issue can be resolved by using the `self` object.  So, this PR creates a `globals.ts` file in the `util` directory that implements this [polyfill](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis).

The codes in the abovementioned files have been refactored to use the polyfill instead of the window object.

I had to use `eslint-disable-next-line no-restricted-globals` to disable the `no-restricted-globals` eslint rule. 