### PR TITLE
feat: export error codes as static properties

### DIFF
--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -8,6 +8,7 @@ export class JOSEError extends Error {
   /**
    * A unique error code for the particular error subclass.
    */
+  static code = 'ERR_JOSE_GENERIC'
   code = 'ERR_JOSE_GENERIC'
 
   constructor(message?: string) {
@@ -23,6 +24,7 @@ export class JOSEError extends Error {
  * An error subclass thrown when a JWT Claim Set member validation fails.
  */
 export class JWTClaimValidationFailed extends JOSEError {
+  static code = 'ERR_JWT_CLAIM_VALIDATION_FAILED'
   code = 'ERR_JWT_CLAIM_VALIDATION_FAILED'
 
   /**
@@ -46,6 +48,7 @@ export class JWTClaimValidationFailed extends JOSEError {
  * An error subclass thrown when a JOSE Algorithm is not allowed per developer preference.
  */
 export class JOSEAlgNotAllowed extends JOSEError {
+  static code = 'ERR_JOSE_ALG_NOT_ALLOWED'
   code = 'ERR_JOSE_ALG_NOT_ALLOWED'
 }
 
@@ -54,6 +57,7 @@ export class JOSEAlgNotAllowed extends JOSEError {
  * implementation or JOSE in general.
  */
 export class JOSENotSupported extends JOSEError {
+  static code = 'ERR_JOSE_NOT_SUPPORTED'
   code = 'ERR_JOSE_NOT_SUPPORTED'
 }
 
@@ -61,6 +65,7 @@ export class JOSENotSupported extends JOSEError {
  * An error subclass thrown when a JWE ciphertext decryption fails.
  */
 export class JWEDecryptionFailed extends JOSEError {
+  static code = 'ERR_JWE_DECRYPTION_FAILED'
   code = 'ERR_JWE_DECRYPTION_FAILED'
 
   message = 'decryption operation failed'
@@ -70,6 +75,7 @@ export class JWEDecryptionFailed extends JOSEError {
  * An error subclass thrown when a JWE is invalid.
  */
 export class JWEInvalid extends JOSEError {
+  static code = 'ERR_JWE_INVALID'
   code = 'ERR_JWE_INVALID'
 }
 
@@ -77,6 +83,7 @@ export class JWEInvalid extends JOSEError {
  * An error subclass thrown when a JWS is invalid.
  */
 export class JWSInvalid extends JOSEError {
+  static code = 'ERR_JWS_INVALID'
   code = 'ERR_JWS_INVALID'
 }
 
@@ -84,6 +91,7 @@ export class JWSInvalid extends JOSEError {
  * An error subclass thrown when a JWT is invalid.
  */
 export class JWTInvalid extends JOSEError {
+  static code = 'ERR_JWT_INVALID'
   code = 'ERR_JWT_INVALID'
 }
 
@@ -91,6 +99,7 @@ export class JWTInvalid extends JOSEError {
  * An error subclass thrown when a JWK is invalid.
  */
 export class JWKInvalid extends JOSEError {
+  static code = 'ERR_JWK_INVALID'
   code = 'ERR_JWK_INVALID'
 }
 
@@ -98,6 +107,7 @@ export class JWKInvalid extends JOSEError {
  * An error subclass thrown when a JWKS is invalid.
  */
 export class JWKSInvalid extends JOSEError {
+  static code = 'ERR_JWKS_INVALID'
   code = 'ERR_JWKS_INVALID'
 }
 
@@ -105,6 +115,7 @@ export class JWKSInvalid extends JOSEError {
  * An error subclass thrown when no keys match from a JWKS.
  */
 export class JWKSNoMatchingKey extends JOSEError {
+  static code = 'ERR_JWKS_NO_MATCHING_KEY'
   code = 'ERR_JWKS_NO_MATCHING_KEY'
 
   message = 'no applicable key found in the JSON Web Key Set'
@@ -114,6 +125,7 @@ export class JWKSNoMatchingKey extends JOSEError {
  * An error subclass thrown when multiple keys match from a JWKS.
  */
 export class JWKSMultipleMatchingKeys extends JOSEError {
+  static code = 'ERR_JWKS_MULTIPLE_MATCHING_KEYS'
   code = 'ERR_JWKS_MULTIPLE_MATCHING_KEYS'
 
   message = 'multiple matching keys found in the JSON Web Key Set'
@@ -123,6 +135,7 @@ export class JWKSMultipleMatchingKeys extends JOSEError {
  * An error subclass thrown when JWS signature verification fails.
  */
 export class JWSSignatureVerificationFailed extends JOSEError {
+  static code = 'ERR_JWS_SIGNATURE_VERIFICATION_FAILED'
   code = 'ERR_JWS_SIGNATURE_VERIFICATION_FAILED'
 
   message = 'signature verification failed'
@@ -132,5 +145,6 @@ export class JWSSignatureVerificationFailed extends JOSEError {
  * An error subclass thrown when a JWT is expired.
  */
 export class JWTExpired extends JWTClaimValidationFailed {
+  static code = 'ERR_JWT_EXPIRED'
   code = 'ERR_JWT_EXPIRED'
 }

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -9,6 +9,7 @@ export class JOSEError extends Error {
    * A unique error code for the particular error subclass.
    */
   static code = 'ERR_JOSE_GENERIC'
+
   code = 'ERR_JOSE_GENERIC'
 
   constructor(message?: string) {
@@ -25,6 +26,7 @@ export class JOSEError extends Error {
  */
 export class JWTClaimValidationFailed extends JOSEError {
   static code = 'ERR_JWT_CLAIM_VALIDATION_FAILED'
+
   code = 'ERR_JWT_CLAIM_VALIDATION_FAILED'
 
   /**
@@ -49,6 +51,7 @@ export class JWTClaimValidationFailed extends JOSEError {
  */
 export class JOSEAlgNotAllowed extends JOSEError {
   static code = 'ERR_JOSE_ALG_NOT_ALLOWED'
+
   code = 'ERR_JOSE_ALG_NOT_ALLOWED'
 }
 
@@ -58,6 +61,7 @@ export class JOSEAlgNotAllowed extends JOSEError {
  */
 export class JOSENotSupported extends JOSEError {
   static code = 'ERR_JOSE_NOT_SUPPORTED'
+
   code = 'ERR_JOSE_NOT_SUPPORTED'
 }
 
@@ -66,6 +70,7 @@ export class JOSENotSupported extends JOSEError {
  */
 export class JWEDecryptionFailed extends JOSEError {
   static code = 'ERR_JWE_DECRYPTION_FAILED'
+
   code = 'ERR_JWE_DECRYPTION_FAILED'
 
   message = 'decryption operation failed'
@@ -76,6 +81,7 @@ export class JWEDecryptionFailed extends JOSEError {
  */
 export class JWEInvalid extends JOSEError {
   static code = 'ERR_JWE_INVALID'
+
   code = 'ERR_JWE_INVALID'
 }
 
@@ -84,6 +90,7 @@ export class JWEInvalid extends JOSEError {
  */
 export class JWSInvalid extends JOSEError {
   static code = 'ERR_JWS_INVALID'
+
   code = 'ERR_JWS_INVALID'
 }
 
@@ -92,6 +99,7 @@ export class JWSInvalid extends JOSEError {
  */
 export class JWTInvalid extends JOSEError {
   static code = 'ERR_JWT_INVALID'
+
   code = 'ERR_JWT_INVALID'
 }
 
@@ -100,6 +108,7 @@ export class JWTInvalid extends JOSEError {
  */
 export class JWKInvalid extends JOSEError {
   static code = 'ERR_JWK_INVALID'
+
   code = 'ERR_JWK_INVALID'
 }
 
@@ -108,6 +117,7 @@ export class JWKInvalid extends JOSEError {
  */
 export class JWKSInvalid extends JOSEError {
   static code = 'ERR_JWKS_INVALID'
+
   code = 'ERR_JWKS_INVALID'
 }
 
@@ -116,6 +126,7 @@ export class JWKSInvalid extends JOSEError {
  */
 export class JWKSNoMatchingKey extends JOSEError {
   static code = 'ERR_JWKS_NO_MATCHING_KEY'
+
   code = 'ERR_JWKS_NO_MATCHING_KEY'
 
   message = 'no applicable key found in the JSON Web Key Set'
@@ -126,6 +137,7 @@ export class JWKSNoMatchingKey extends JOSEError {
  */
 export class JWKSMultipleMatchingKeys extends JOSEError {
   static code = 'ERR_JWKS_MULTIPLE_MATCHING_KEYS'
+
   code = 'ERR_JWKS_MULTIPLE_MATCHING_KEYS'
 
   message = 'multiple matching keys found in the JSON Web Key Set'
@@ -136,6 +148,7 @@ export class JWKSMultipleMatchingKeys extends JOSEError {
  */
 export class JWSSignatureVerificationFailed extends JOSEError {
   static code = 'ERR_JWS_SIGNATURE_VERIFICATION_FAILED'
+
   code = 'ERR_JWS_SIGNATURE_VERIFICATION_FAILED'
 
   message = 'signature verification failed'
@@ -146,5 +159,6 @@ export class JWSSignatureVerificationFailed extends JOSEError {
  */
 export class JWTExpired extends JWTClaimValidationFailed {
   static code = 'ERR_JWT_EXPIRED'
+
   code = 'ERR_JWT_EXPIRED'
 }

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -10,7 +10,7 @@ export class JOSEError extends Error {
    */
   static code = 'ERR_JOSE_GENERIC'
 
-  code = 'ERR_JOSE_GENERIC'
+  code = JOSEError.code
 
   constructor(message?: string) {
     super(message)
@@ -27,7 +27,7 @@ export class JOSEError extends Error {
 export class JWTClaimValidationFailed extends JOSEError {
   static code = 'ERR_JWT_CLAIM_VALIDATION_FAILED'
 
-  code = 'ERR_JWT_CLAIM_VALIDATION_FAILED'
+  code = JWTClaimValidationFailed.code
 
   /**
    * The Claim for which the validation failed.
@@ -52,7 +52,7 @@ export class JWTClaimValidationFailed extends JOSEError {
 export class JOSEAlgNotAllowed extends JOSEError {
   static code = 'ERR_JOSE_ALG_NOT_ALLOWED'
 
-  code = 'ERR_JOSE_ALG_NOT_ALLOWED'
+  code = JOSEAlgNotAllowed.code
 }
 
 /**
@@ -62,7 +62,7 @@ export class JOSEAlgNotAllowed extends JOSEError {
 export class JOSENotSupported extends JOSEError {
   static code = 'ERR_JOSE_NOT_SUPPORTED'
 
-  code = 'ERR_JOSE_NOT_SUPPORTED'
+  code = JOSENotSupported.code
 }
 
 /**
@@ -71,7 +71,7 @@ export class JOSENotSupported extends JOSEError {
 export class JWEDecryptionFailed extends JOSEError {
   static code = 'ERR_JWE_DECRYPTION_FAILED'
 
-  code = 'ERR_JWE_DECRYPTION_FAILED'
+  code = JWEDecryptionFailed.code
 
   message = 'decryption operation failed'
 }
@@ -82,7 +82,7 @@ export class JWEDecryptionFailed extends JOSEError {
 export class JWEInvalid extends JOSEError {
   static code = 'ERR_JWE_INVALID'
 
-  code = 'ERR_JWE_INVALID'
+  code = JWEInvalid.code
 }
 
 /**
@@ -91,7 +91,7 @@ export class JWEInvalid extends JOSEError {
 export class JWSInvalid extends JOSEError {
   static code = 'ERR_JWS_INVALID'
 
-  code = 'ERR_JWS_INVALID'
+  code = JWSInvalid.code
 }
 
 /**
@@ -100,7 +100,7 @@ export class JWSInvalid extends JOSEError {
 export class JWTInvalid extends JOSEError {
   static code = 'ERR_JWT_INVALID'
 
-  code = 'ERR_JWT_INVALID'
+  code = JWTInvalid.code
 }
 
 /**
@@ -109,7 +109,7 @@ export class JWTInvalid extends JOSEError {
 export class JWKInvalid extends JOSEError {
   static code = 'ERR_JWK_INVALID'
 
-  code = 'ERR_JWK_INVALID'
+  code = JWKInvalid.code
 }
 
 /**
@@ -118,7 +118,7 @@ export class JWKInvalid extends JOSEError {
 export class JWKSInvalid extends JOSEError {
   static code = 'ERR_JWKS_INVALID'
 
-  code = 'ERR_JWKS_INVALID'
+  code = JWKSInvalid.code
 }
 
 /**
@@ -127,7 +127,7 @@ export class JWKSInvalid extends JOSEError {
 export class JWKSNoMatchingKey extends JOSEError {
   static code = 'ERR_JWKS_NO_MATCHING_KEY'
 
-  code = 'ERR_JWKS_NO_MATCHING_KEY'
+  code = JWKSNoMatchingKey.code
 
   message = 'no applicable key found in the JSON Web Key Set'
 }
@@ -138,7 +138,7 @@ export class JWKSNoMatchingKey extends JOSEError {
 export class JWKSMultipleMatchingKeys extends JOSEError {
   static code = 'ERR_JWKS_MULTIPLE_MATCHING_KEYS'
 
-  code = 'ERR_JWKS_MULTIPLE_MATCHING_KEYS'
+  code = JWKSMultipleMatchingKeys.code
 
   message = 'multiple matching keys found in the JSON Web Key Set'
 }
@@ -149,7 +149,7 @@ export class JWKSMultipleMatchingKeys extends JOSEError {
 export class JWSSignatureVerificationFailed extends JOSEError {
   static code = 'ERR_JWS_SIGNATURE_VERIFICATION_FAILED'
 
-  code = 'ERR_JWS_SIGNATURE_VERIFICATION_FAILED'
+  code = JWSSignatureVerificationFailed.code
 
   message = 'signature verification failed'
 }
@@ -160,5 +160,5 @@ export class JWSSignatureVerificationFailed extends JOSEError {
 export class JWTExpired extends JWTClaimValidationFailed {
   static code = 'ERR_JWT_EXPIRED'
 
-  code = 'ERR_JWT_EXPIRED'
+  code = JWTExpired.code
 }


### PR DESCRIPTION
This is just to make it possible to get the code, without having to create a new instance of the class.

In our use case, we emit a metric with the error code on some failures. The unit tests look like:

```ts
assert(emittedMetric === new JWTExpired("test message").code);
```

which isn't nearly as clean as:
```ts
assert(emittedMetric === JWTExpired.code);
```
Discussion is [here](https://github.com/panva/jose/discussions/170)