### PR TITLE
fix(browser): avoid global-conflicting variable name fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -336,7 +336,7 @@
     "lint": "eslint --config ./src/.eslintrc.json ./src",
     "runtime-browser": "run-s runtime:clear runtime:browser:* runtime:refs",
     "runtime-node": "run-s runtime:clear runtime:node:* runtime:refs",
-    "runtime-node-webcrypto": "run-s runtime:clear runtime:browser:* && cp ./src/runtime/node/webcrypto.ts ./src/runtime/ && cp ./src/runtime/node/fetch.ts ./src/runtime/ && cp ./src/runtime/node/base64url.ts ./src/runtime/ && cp ./src/runtime/node/zlib.ts ./src/runtime/ && run-s runtime:refs",
+    "runtime-node-webcrypto": "run-s runtime:clear runtime:browser:* && cp ./src/runtime/node/webcrypto.ts ./src/runtime/ && cp ./src/runtime/node/fetch_jwks.ts ./src/runtime/ && cp ./src/runtime/node/base64url.ts ./src/runtime/ && cp ./src/runtime/node/zlib.ts ./src/runtime/ && run-s runtime:refs",
     "runtime:browser:copy": "cp ./src/runtime/browser/*.ts ./src/runtime",
     "runtime:clear": "run-s -s runtime:find | xargs -0 rm -f",
     "runtime:find": "find src/runtime -not -name '*.d.ts' -maxdepth 1 -type f -print0",

--- a/src/jwks/remote.ts
+++ b/src/jwks/remote.ts
@@ -10,7 +10,7 @@ import {
   JWKSNoMatchingKey,
   JWKSMultipleMatchingKeys,
 } from '../util/errors.js'
-import fetchJson from '../runtime/fetch.js'
+import fetchJwks from '../runtime/fetch_jwks.js'
 import isObject from '../lib/is_object.js'
 
 function getKtyFromAlg(alg: string) {
@@ -187,7 +187,7 @@ class RemoteJWKSet {
 
   async reload() {
     if (!this._pendingFetch) {
-      this._pendingFetch = fetchJson(this._url, this._timeoutDuration, this._options)
+      this._pendingFetch = fetchJwks(this._url, this._timeoutDuration, this._options)
         .then((json) => {
           if (
             typeof json !== 'object' ||

--- a/src/runtime/browser/fetch.ts
+++ b/src/runtime/browser/fetch.ts
@@ -2,7 +2,7 @@ import type { FetchFunction } from '../interfaces.d'
 import { JOSEError } from '../../util/errors.js'
 import globalThis from './global.js'
 
-const fetch: FetchFunction = async (url: URL, timeout: number) => {
+const fetchJSON: FetchFunction = async (url: URL, timeout: number) => {
   let controller!: AbortController
   if (typeof AbortController === 'function') {
     controller = new AbortController()
@@ -28,4 +28,4 @@ const fetch: FetchFunction = async (url: URL, timeout: number) => {
     throw new JOSEError('Failed to parse the JSON Web Key Set HTTP response as JSON')
   }
 }
-export default fetch
+export default fetchJSON

--- a/src/runtime/browser/fetch_jwks.ts
+++ b/src/runtime/browser/fetch_jwks.ts
@@ -2,7 +2,7 @@ import type { FetchFunction } from '../interfaces.d'
 import { JOSEError } from '../../util/errors.js'
 import globalThis from './global.js'
 
-const fetchJSON: FetchFunction = async (url: URL, timeout: number) => {
+const fetchJwks: FetchFunction = async (url: URL, timeout: number) => {
   let controller!: AbortController
   if (typeof AbortController === 'function') {
     controller = new AbortController()
@@ -28,4 +28,4 @@ const fetchJSON: FetchFunction = async (url: URL, timeout: number) => {
     throw new JOSEError('Failed to parse the JSON Web Key Set HTTP response as JSON')
   }
 }
-export default fetchJSON
+export default fetchJwks

--- a/src/runtime/node/fetch_jwks.ts
+++ b/src/runtime/node/fetch_jwks.ts
@@ -15,7 +15,11 @@ const protocols: { [protocol: string]: (...args: Parameters<typeof https>) => Cl
 
 type AcceptedRequestOptions = Pick<RequestOptions, 'agent'>
 
-const fetch: FetchFunction = async (url: URL, timeout: number, options: AcceptedRequestOptions) => {
+const fetchJwks: FetchFunction = async (
+  url: URL,
+  timeout: number,
+  options: AcceptedRequestOptions,
+) => {
   if (protocols[url.protocol] === undefined) {
     throw new TypeError('Unsupported URL protocol.')
   }
@@ -46,4 +50,4 @@ const fetch: FetchFunction = async (url: URL, timeout: number, options: Accepted
   }
 }
 
-export default fetch
+export default fetchJwks


### PR DESCRIPTION
Here's a tiny fix that should hopefully save a lot of people a lot of headaches.

esbuild (and apparently other bundlers too) when outputting a single JS module (for esbuild, that's in `--format=esm`), everything is concatenated in a single file and de-scoped.

Because jose defines a variable called `fetch`, that overrode the `window.fetch` method, and it was causing all fetch requests in my app to fail.

Took a while to figure out. I was able to find a workaround by switching esbuild to `--format=iife`, which was fine for my app, but if someone needs an output as esm, they are stuck.