### PR TITLE
Add top-level exports for all API's

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
   "module": "./dist/browser/index.js",
   "exports": {
     "./package.json": "./package.json",
+    ".": {
+      "browser": "./dist/node/esm/index.js",
+      "import": "./dist/node/esm/index.js",
+      "require": "./dist/node/cjs/index.js"
+    },
     "./jwe/compact/decrypt": {
       "browser": "./dist/browser/jwe/compact/decrypt.js",
       "import": "./dist/node/esm/jwe/compact/decrypt.js",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
       "require": "./dist/node/webcrypto/cjs/*.js"
     }
   },
+  "module": "./dist/browser/index.js",
   "exports": {
     "./package.json": "./package.json",
     "./jwe/compact/decrypt": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,53 @@
+export type {
+  KeyLike,
+  DecryptOptions,
+  JWEKeyManagementHeaderParameters,
+  JWEHeaderParameters,
+  FlattenedJWE,
+  JWK,
+  JWSHeaderParameters,
+  VerifyOptions,
+  FlattenedJWS,
+  FlattenedJWSInput,
+  GetKeyFunction,
+  GeneralJWS,
+  GeneralJWSInput,
+  JWTPayload,
+} from "./types.d";
+
+export { compactDecrypt, CompactDecryptGetKey } from "./jwe/compact/decrypt";
+export { CompactEncrypt } from "./jwe/compact/encrypt";
+
+export { flattenedDecrypt, FlattenedDecryptGetKey } from "./jwe/flattened/decrypt";
+export { FlattenedEncrypt } from "./jwe/flattened/encrypt";
+
+export { generalDecrypt, GeneralDecryptGetKey } from "./jwe/general/decrypt";
+
+export { EmbeddedJWK } from "./jwk/embedded";
+export { fromKeyLike } from "./jwk/from_key_like";
+export { parseJwk } from "./jwk/parse";
+export { calculateThumbprint } from "./jwk/thumbprint";
+
+export { createRemoteJWKSet, RemoteJWKSetOptions } from "./jwks/remote";
+
+export { CompactSign } from "./jws/compact/sign";
+export { compactVerify, CompactVerifyGetKey } from "./jws/compact/verify";
+
+export { FlattenedSign } from "./jws/flattened/sign";
+export { flattenedVerify, FlattenedVerifyGetKey } from "./jws/flattened/verify";
+
+export { GeneralSign, Signature } from "./jws/general/sign";
+export { generalVerify, GeneralVerifyGetKey } from "./jws/general/verify";
+
+export { jwtDecrypt, JWTDecryptOptions, JWTDecryptGetKey } from "./jwt/decrypt";
+export { EncryptJWT } from "./jwt/encrypt";
+export { SignJWT } from "./jwt/sign";
+export { UnsecuredJWT } from "./jwt/unsecured";
+export { jwtVerify, JWTVerifyOptions } from "./jwt/verify";
+
+export { encode as base64UrlEncode, decode as base64UrlDecode } from "./util/base64url";
+export { decodeProtectedHeader, ProtectedHeaderParameters } from "./util/decode_protected_header";
+export * from "./util/errors";
+export { generateKeyPair, GenerateKeyPairOptions } from "./util/generate_key_pair";
+export { generateSecret, GenerateSecretOptions } from "./util/generate_secret";
+export { random } from "./util/random";

--- a/tsconfig/base.json
+++ b/tsconfig/base.json
@@ -1,5 +1,7 @@
 {
   "files": [
+    "../src/index.ts",
+
     "../src/jwe/compact/encrypt.ts",
     "../src/jwe/compact/decrypt.ts",
     "../src/jwe/flattened/encrypt.ts",


### PR DESCRIPTION
This will make those API's available to bundlers that do not (yet)
support exports maps, as per https://github.com/panva/jose/discussions/201. Once they do, people using those bundlers
will be able to seamlessly switch to using named imports.

I verified that this enabled importing from `jose` directly using at least Parcel v2.

Future API additions will not automatically be exposed. However, hopefully by that time enough of the ecosystem has caught up that people can just use the named exports. What I would do is simply not mention the ability to import from the top level anywhere, but only mention it as a workaround people can do at their own risk if their tooling does not support named imports yet - but up to you of course :)