### PR TITLE
feat(typescript): export consume module interface types

### DIFF
--- a/package.json
+++ b/package.json
@@ -349,7 +349,7 @@
     "test-webcrypto": "WEBCRYPTO=true npm test"
   },
   "devDependencies": {
-    "@types/node": "^15.0.1",
+    "@types/node": "^15.12.4",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "ava": "^3.13.0",
     "bowser": "^2.11.0",

--- a/src/jwe/compact/decrypt.ts
+++ b/src/jwe/compact/decrypt.ts
@@ -87,4 +87,4 @@ async function compactDecrypt(
 
 export { compactDecrypt }
 export default compactDecrypt
-export type { KeyLike, DecryptOptions }
+export type { KeyLike, DecryptOptions, CompactDecryptResult }

--- a/src/jwe/flattened/decrypt.ts
+++ b/src/jwe/flattened/decrypt.ts
@@ -238,4 +238,4 @@ async function flattenedDecrypt(
 
 export { flattenedDecrypt }
 export default flattenedDecrypt
-export type { KeyLike, FlattenedJWE, JWEHeaderParameters, DecryptOptions }
+export type { KeyLike, FlattenedJWE, JWEHeaderParameters, DecryptOptions, FlattenedDecryptResult }

--- a/src/jwe/general/decrypt.ts
+++ b/src/jwe/general/decrypt.ts
@@ -101,4 +101,4 @@ async function generalDecrypt(
 
 export { generalDecrypt }
 export default generalDecrypt
-export type { KeyLike, GeneralJWE, DecryptOptions }
+export type { KeyLike, GeneralJWE, DecryptOptions, GeneralDecryptResult }

--- a/src/jws/compact/verify.ts
+++ b/src/jws/compact/verify.ts
@@ -82,4 +82,4 @@ async function compactVerify(
 
 export { compactVerify }
 export default compactVerify
-export type { KeyLike, VerifyOptions }
+export type { KeyLike, VerifyOptions, CompactVerifyResult }

--- a/src/jws/flattened/verify.ts
+++ b/src/jws/flattened/verify.ts
@@ -183,4 +183,11 @@ async function flattenedVerify(
 
 export { flattenedVerify }
 export default flattenedVerify
-export type { KeyLike, FlattenedJWSInput, GetKeyFunction, JWSHeaderParameters, VerifyOptions }
+export type {
+  KeyLike,
+  FlattenedJWSInput,
+  GetKeyFunction,
+  JWSHeaderParameters,
+  VerifyOptions,
+  FlattenedVerifyResult,
+}

--- a/src/jws/general/verify.ts
+++ b/src/jws/general/verify.ts
@@ -93,4 +93,4 @@ async function generalVerify(
 
 export { generalVerify }
 export default generalVerify
-export type { KeyLike, GeneralJWSInput, VerifyOptions }
+export type { KeyLike, GeneralJWSInput, VerifyOptions, GeneralVerifyResult }

--- a/src/jwt/decrypt.ts
+++ b/src/jwt/decrypt.ts
@@ -95,4 +95,4 @@ async function jwtDecrypt(
 
 export { jwtDecrypt }
 export default jwtDecrypt
-export type { KeyLike, DecryptOptions, JWTPayload, JWTDecryptOptions }
+export type { KeyLike, DecryptOptions, JWTPayload, JWTDecryptOptions, JWTDecryptResult }

--- a/src/jwt/unsecured.ts
+++ b/src/jwt/unsecured.ts
@@ -7,6 +7,11 @@ import { JWTInvalid } from '../util/errors.js'
 import jwtPayload from '../lib/jwt_claims_set.js'
 import ProduceJWT from '../lib/jwt_producer.js'
 
+interface UnsecuredResult {
+  payload: JWTPayload
+  header: JWSHeaderParameters
+}
+
 /**
  * The UnsecuredJWT class is a utility for dealing with `{ "alg": "none" }` Unsecured JWTs.
  *
@@ -59,10 +64,7 @@ class UnsecuredJWT extends ProduceJWT {
    * @param jwt Unsecured JWT to decode the payload of.
    * @param options JWT Claims Set validation options.
    */
-  static decode(
-    jwt: string,
-    options?: JWTClaimVerificationOptions,
-  ): { payload: JWTPayload; header: JWSHeaderParameters } {
+  static decode(jwt: string, options?: JWTClaimVerificationOptions): UnsecuredResult {
     if (typeof jwt !== 'string') {
       throw new JWTInvalid('Unsecured JWT must be a string')
     }
@@ -88,4 +90,4 @@ class UnsecuredJWT extends ProduceJWT {
 
 export { UnsecuredJWT }
 export default UnsecuredJWT
-export type { JWSHeaderParameters, JWTPayload }
+export type { JWSHeaderParameters, JWTPayload, UnsecuredResult }

--- a/src/jwt/verify.ts
+++ b/src/jwt/verify.ts
@@ -71,4 +71,4 @@ async function jwtVerify(
 
 export { jwtVerify }
 export default jwtVerify
-export type { KeyLike, JWTPayload, JWTVerifyOptions, JWSHeaderParameters, GetKeyFunction }
+export type { KeyLike, JWTPayload, JWTVerifyOptions, JWSHeaderParameters, GetKeyFunction, JWTVerifyResult }

--- a/src/jwt/verify.ts
+++ b/src/jwt/verify.ts
@@ -71,4 +71,11 @@ async function jwtVerify(
 
 export { jwtVerify }
 export default jwtVerify
-export type { KeyLike, JWTPayload, JWTVerifyOptions, JWSHeaderParameters, GetKeyFunction, JWTVerifyResult }
+export type {
+  KeyLike,
+  JWTPayload,
+  JWTVerifyOptions,
+  JWSHeaderParameters,
+  GetKeyFunction,
+  JWTVerifyResult,
+}

--- a/src/runtime/node/check_modulus_length.ts
+++ b/src/runtime/node/check_modulus_length.ts
@@ -49,7 +49,6 @@ const getModulusLength = (key: KeyObject): number => {
   }
 
   const modulusLength: number =
-    // @ts-expect-error
     key.asymmetricKeyDetails?.modulusLength ??
     (getLengthOfSeqIndex(
       key.export({ format: 'der', type: 'pkcs1' }),

--- a/src/runtime/node/webcrypto.ts
+++ b/src/runtime/node/webcrypto.ts
@@ -17,7 +17,7 @@ if (util.types.isCryptoKey) {
 } else if (webcrypto) {
   impl = function isCryptoKey(obj): obj is CryptoKey {
     //@ts-expect-error
-    return obj != null && obj instanceof webcrypto.CryptoKey;
+    return obj != null && obj instanceof webcrypto.CryptoKey
   }
 } else {
   // @ts-expect-error

--- a/src/util/decode_protected_header.ts
+++ b/src/util/decode_protected_header.ts
@@ -58,4 +58,3 @@ function decodeProtectedHeader(token: string | object) {
 
 export { decodeProtectedHeader }
 export default decodeProtectedHeader
-export type { ProtectedHeaderParameters }

--- a/src/util/decode_protected_header.ts
+++ b/src/util/decode_protected_header.ts
@@ -44,11 +44,11 @@ function decodeProtectedHeader(token: string | object) {
 
   try {
     if (typeof protectedB64u !== 'string' || !protectedB64u) {
-      throw new Error();
+      throw new Error()
     }
     const result = JSON.parse(decoder.decode(base64url(protectedB64u!)))
     if (!isObject(result)) {
-      throw new Error();
+      throw new Error()
     }
     return <ProtectedHeaderParameters>result
   } catch (err) {
@@ -58,3 +58,4 @@ function decodeProtectedHeader(token: string | object) {
 
 export { decodeProtectedHeader }
 export default decodeProtectedHeader
+export type { ProtectedHeaderParameters }


### PR DESCRIPTION
Exporting type `JWTVerifyResult` from `jose/jwt/verify`

I did not see any way to `import { JWTVerifyResult }` with the existing import maps.  Apologies if this is redundant.

Thank you for a great library!