### PR TITLE
feat: throw custom error when jws protected header is not valid json

### DIFF
--- a/src/jws/flattened/verify.ts
+++ b/src/jws/flattened/verify.ts
@@ -95,7 +95,11 @@ async function flattenedVerify(
   let parsedProt: JWSHeaderParameters = {}
   if (jws.protected) {
     const protectedHeader = base64url(jws.protected)
-    parsedProt = JSON.parse(decoder.decode(protectedHeader))
+    try {
+      parsedProt = JSON.parse(decoder.decode(protectedHeader))
+    } catch {
+      throw new JWSInvalid('JWS Protected Header is invalid')
+    }
   }
   if (!isDisjoint(parsedProt, jws.header)) {
     throw new JWSInvalid(

--- a/test/jws/flattened.verify.test.mjs
+++ b/test/jws/flattened.verify.test.mjs
@@ -75,6 +75,16 @@ Promise.all([
       {
         const jws = { ...fullJws };
         const assertion = {
+          message: 'JWS Protected Header is invalid',
+          code: 'ERR_JWS_INVALID',
+        };
+        jws.protected = `1${jws.protected}`;
+        await t.throwsAsync(flattenedVerify(jws, t.context.secret), assertion);
+      }
+
+      {
+        const jws = { ...fullJws };
+        const assertion = {
           message: 'JWS Payload missing',
           code: 'ERR_JWS_INVALID',
         };


### PR DESCRIPTION
This PR adds additional check in JWS verification allowing for catching malformed JWS protected header. Previously, when user provided token which "appeared" like a well-formed JWS, but in reality protected header could not be `JSON.parse`-d, `SyntaxError` would be thrown. With this PR, `JWSInvalid('JWS Protected Header is invalid')` is thrown.

E.g., having JWT (with `1` prepended):

```
1eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb3NlLXRlc3QiLCJpYXQiOjE2MjkxMDM1NDksImV4cCI6MTY2MDcyNTk0OSwiYXVkIjoiam9zZS10ZXN0Iiwic3ViIjoiam9zZS10ZXN0In0.FWiGkd6idzmcw9JhmLuoOjtnDXhiOOF0bFuPcw4Nn8Y
```

Previously, when using `jwtVerify`:
```
SyntaxError: Unexpected token i in JSON at position 0
``` 

was thrown. After this PR, `JWSInvalid` error with message `JWS Protected Header is invalid` and can be handled by user.