### PR TITLE
Add additional fetch options

### DIFF
--- a/src/runtime/browser/fetch_jwks.ts
+++ b/src/runtime/browser/fetch_jwks.ts
@@ -2,20 +2,28 @@ import type { FetchFunction } from '../interfaces.d'
 import { JOSEError } from '../../util/errors.js'
 import globalThis from './global.js'
 
+let createAbortSignal = (ms?: number) => {
+  if (typeof AbortController !== 'function') { return }
+    const controller = new AbortController()
+    setTimeout(() => controller.abort(), ms)
+    return controller.signal
+}
+
+const isCloudflareWorker = ("mode" in new Request(""))
+
 const fetchJwks: FetchFunction = async (url: URL, timeout: number) => {
-  let controller!: AbortController
-  if (typeof AbortController === 'function') {
-    controller = new AbortController()
-    setTimeout(() => controller.abort(), timeout)
-  }
+  const signal = createAbortSignal(timeout)
+  const referrerPolicy = !isCloudflareWorker ? 'no-referrer' : undefined
+  const credentials =    !isCloudflareWorker ? 'omit' : undefined
+  const mode =           !isCloudflareWorker ? 'cors' : undefined
 
   const response = await globalThis.fetch(url.href, {
-    signal: controller ? controller.signal : undefined,
     redirect: 'manual',
-    referrerPolicy: 'no-referrer',
-    credentials: 'omit',
-    mode: 'cors',
     method: 'GET',
+    signal,
+    referrerPolicy,
+    credentials,
+    mode,
   })
 
   if (response.status !== 200) {


### PR DESCRIPTION
Thank you for the fantastic library of JSON Web functions.

I have been trying to use `jose-browser-runtime/jwks/remote` inside [Cloudflare workers](https://workers.cloudflare.com/) 
Although the code executes server side, the Cloudflare workers environment lacks many of node-js libraries. The environment is much more similar to a [web worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers) running insider a browser.

Cloudflare provides a [fetch function](https://developers.cloudflare.com/workers/runtime-apis/fetch#properties) very similar to the [standard fetch function](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API), however [Cloudflare's Request parameter](https://developers.cloudflare.com/workers/runtime-apis/request#requestinit) lacks some of the properties in the [standard Request parameter](https://developer.mozilla.org/en-US/docs/Web/API/Request).

Unfortunately, if the user provides Request parameter options such as `mode` ,  `credentials` or `referrerPolicy`, then  Cloudflare's fetch function will throw an error of the form

> The 'mode' field on 'RequestInitializerDict' is not implemented.

Other libraries such as the aws sdk have encounter similar issues while being used inside cloudflare workers.
https://github.com/aws/aws-sdk-js-v3/issues/1165

Currently these parameters are specified by the library and can not be configured. 
https://github.com/panva/jose/blob/main/src/runtime/browser/fetch_jwks.ts#L15-L17

This pull request allows the user to configure/override these default parameters with `undefined` values, so that it can be used inside cloudflare workers.

