### PR TITLE
Export type ProduceJWT

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export { jwtVerify } from './jwt/verify.js'
 export type { JWTVerifyOptions, JWTVerifyGetKey } from './jwt/verify.js'
 export { jwtDecrypt } from './jwt/decrypt.js'
 export type { JWTDecryptOptions, JWTDecryptGetKey } from './jwt/decrypt.js'
+export type { ProduceJWT } from './jwt/produce.js'
 
 export { CompactEncrypt } from './jwe/compact/encrypt.js'
 export { FlattenedEncrypt } from './jwe/flattened/encrypt.js'


### PR DESCRIPTION
It is useful for type declaration:

```ts
function configJWT(jwt: ProduceJWT, config: Configuration) {
  // ...
}

const signJWT = new SignJWT(payload);
const encJWT = new EncryptJWT(payload);

// share for sign and encrypt
configJWT(signJWT, config);
configJWT(encJWT, config);
```