### PR TITLE
fix(typescript): Make b64 header optional

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -734,7 +734,7 @@ export interface CompactJWSHeaderParameters extends JWSHeaderParameters {
  * may also be present.
  */
 export interface JWTHeaderParameters extends CompactJWSHeaderParameters {
-  b64: never
+  b64?: never
 }
 
 /**


### PR DESCRIPTION
The b64 header is currently defined as a required field, so omitting it throws a typescript error. Since its type is defined as "never", there is nothing that can be assigned to it, making it impossible to actually use.
This makes b64 optional, which still prevents assigning to it due to the type.