### PR TITLE
fix decode example of UnsecuredJWT

### DIFF
--- a/docs/classes/jwt_unsecured.UnsecuredJWT.md
+++ b/docs/classes/jwt_unsecured.UnsecuredJWT.md
@@ -16,7 +16,7 @@ console.log(unsecuredJwt)
 
 **`example`** Decoding
 ```js
-const payload = new jose.UnsecuredJWT.decode(jwt, {
+const payload = jose.UnsecuredJWT.decode(jwt, {
   issuer: 'urn:example:issuer',
   audience: 'urn:example:audience'
 })

--- a/src/jwt/unsecured.ts
+++ b/src/jwt/unsecured.ts
@@ -28,7 +28,7 @@ export interface UnsecuredResult {
  *
  * @example Decoding
  * ```js
- * const payload = new jose.UnsecuredJWT.decode(jwt, {
+ * const payload = jose.UnsecuredJWT.decode(jwt, {
  *   issuer: 'urn:example:issuer',
  *   audience: 'urn:example:audience'
  * })


### PR DESCRIPTION
`.decode()` is a static function of the `UnsecuredJWT` class. Instantiating a new object and calling the function afterwards doesn't make sense and leads to an exception:

```
const payload = new jose.UnsecuredJWT.decode(unsecuredJwt, {
                ^

TypeError: jose.UnsecuredJWT.decode is not a constructor
    at file:///Users/maxarndt/Downloads/some-repo/utilities/jwt/unsecuredJWT.js:12:17
    at ModuleJob.run (node:internal/modules/esm/module_job:185:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:281:24)
    at async loadESM (node:internal/process/esm_loader:88:5)
    at async handleMainPromise (node:internal/modules/run_main:65:12)
```

Because of this the `new` operator should be removed from the examples. 