### PR TITLE
Support decrypting empty ciphertext

### DIFF
--- a/src/jwe/compact/decrypt.ts
+++ b/src/jwe/compact/decrypt.ts
@@ -77,7 +77,7 @@ export async function compactDecrypt(
 
   const decrypted = await flattenedDecrypt(
     {
-      ciphertext: <string>(ciphertext || undefined),
+      ciphertext,
       iv: <string>(iv || undefined),
       protected: protectedHeader || undefined,
       tag: <string>(tag || undefined),

--- a/test/jwe/compact.decrypt.test.mjs
+++ b/test/jwe/compact.decrypt.test.mjs
@@ -16,13 +16,12 @@ test('JWE format validation', async (t) => {
 
 test('decrypt empty data', async (t) => {
   const jwe = await new CompactEncrypt(new Uint8Array(0))
-    .setInitializationVector(new Uint8Array(12))
     .setProtectedHeader({ alg: 'dir', enc: 'A128GCM' })
     .encrypt(new Uint8Array(16))
 
   const { 3: ciphertext } = jwe.split('.')
-  t.deepEqual(ciphertext, '')
+  t.is(ciphertext, '')
 
   const { plaintext } = await compactDecrypt(jwe, new Uint8Array(16))
-  t.deepEqual(plaintext.length, 0)
+  t.is(plaintext.byteLength, 0)
 })

--- a/test/jwe/compact.decrypt.test.mjs
+++ b/test/jwe/compact.decrypt.test.mjs
@@ -1,7 +1,7 @@
 import test from 'ava'
 
 const root = !('WEBCRYPTO' in process.env) ? '#dist' : '#dist/webcrypto'
-const { compactDecrypt } = await import(root)
+const { CompactEncrypt, compactDecrypt } = await import(root)
 
 test('JWE format validation', async (t) => {
   await t.throwsAsync(compactDecrypt(null, new Uint8Array(0)), {
@@ -12,4 +12,17 @@ test('JWE format validation', async (t) => {
     message: 'Invalid Compact JWE',
     code: 'ERR_JWE_INVALID',
   })
+})
+
+test('decrypt empty data', async (t) => {
+  const jwe = await new CompactEncrypt(new Uint8Array(0))
+    .setInitializationVector(new Uint8Array(12))
+    .setProtectedHeader({ alg: 'dir', enc: 'A128GCM' })
+    .encrypt(new Uint8Array(16))
+
+  const { 3: ciphertext } = jwe.split('.')
+  t.deepEqual(ciphertext, '')
+
+  const { plaintext } = await compactDecrypt(jwe, new Uint8Array(16))
+  t.deepEqual(plaintext.length, 0)
 })

--- a/test/jwe/compact.decrypt.test.mjs
+++ b/test/jwe/compact.decrypt.test.mjs
@@ -19,8 +19,7 @@ test('decrypt empty data', async (t) => {
     .setProtectedHeader({ alg: 'dir', enc: 'A128GCM' })
     .encrypt(new Uint8Array(16))
 
-  const { 3: ciphertext } = jwe.split('.')
-  t.is(ciphertext, '')
+  t.is(jwe.split('.')[3], '')
 
   const { plaintext } = await compactDecrypt(jwe, new Uint8Array(16))
   t.is(plaintext.byteLength, 0)

--- a/test/jwe/flattened.decrypt.test.mjs
+++ b/test/jwe/flattened.decrypt.test.mjs
@@ -217,3 +217,14 @@ test('AES CBC + HMAC', async (t) => {
     })
   }
 })
+
+test('decrypt empty data', async (t) => {
+  const jwe = await new FlattenedEncrypt(new Uint8Array(0))
+    .setProtectedHeader({ alg: 'dir', enc: 'A128GCM' })
+    .encrypt(new Uint8Array(16))
+
+  t.is(jwe.ciphertext, '')
+
+  const { plaintext } = await flattenedDecrypt(jwe, new Uint8Array(16))
+  t.is(plaintext.byteLength, 0)
+})

--- a/test/jwe/general.test.mjs
+++ b/test/jwe/general.test.mjs
@@ -170,3 +170,15 @@ test('General JWE format validation', async (t) => {
     await t.notThrowsAsync(generalDecrypt(jwe, t.context.secret))
   }
 })
+
+test('decrypt empty data', async (t) => {
+  const jwe = await new GeneralEncrypt(new Uint8Array(0))
+    .setProtectedHeader({ alg: 'dir', enc: 'A128GCM' })
+    .addRecipient(new Uint8Array(16))
+    .encrypt()
+
+  t.is(jwe.ciphertext, '')
+
+  const { plaintext } = await generalDecrypt(jwe, new Uint8Array(16))
+  t.is(plaintext.byteLength, 0)
+})


### PR DESCRIPTION
When encrypting an empty string/buffer in GCM mode, the resulting ciphertext is also empty. Trying to then decrypt this using compact decryption then throws an error because it converts the empty string to undefined and then throws an error.
This is probably an edge case, but it is valid to encrypt and decrypt an empty value. This is also not an issue in CBC mode, since the ciphertext of an empty value is a non-empty value.