### PR TITLE
Add optional headers for fetch_jwk

### DIFF
--- a/src/jwks/remote.ts
+++ b/src/jwks/remote.ts
@@ -1,9 +1,7 @@
-import fetchJwks from '../runtime/fetch_jwks.js'
 import { isCloudflareWorkers } from '../runtime/env.js'
-
-import type { KeyLike, JWSHeaderParameters, FlattenedJWSInput, GetKeyFunction } from '../types.d'
+import fetchJwks from '../runtime/fetch_jwks.js'
+import type { FlattenedJWSInput, GetKeyFunction, JWSHeaderParameters, KeyLike } from '../types.d'
 import { JWKSInvalid, JWKSNoMatchingKey } from '../util/errors.js'
-
 import { isJWKSLike, LocalJWKSet } from './local.js'
 
 /**
@@ -42,6 +40,11 @@ export interface RemoteJWKSetOptions {
    * runtime.
    */
   agent?: any
+
+  /**
+   * Optional headers to be sent with the HTTP request.
+   */
+  headers?: Record<string, string>
 }
 
 class RemoteJWKSet extends LocalJWKSet {
@@ -57,7 +60,7 @@ class RemoteJWKSet extends LocalJWKSet {
 
   private _pendingFetch?: Promise<unknown>
 
-  private _options: Pick<RemoteJWKSetOptions, 'agent'>
+  private _options: Pick<RemoteJWKSetOptions, 'agent' | 'headers'>
 
   constructor(url: unknown, options?: RemoteJWKSetOptions) {
     super({ keys: [] })
@@ -68,7 +71,7 @@ class RemoteJWKSet extends LocalJWKSet {
       throw new TypeError('url must be an instance of URL')
     }
     this._url = new URL(url.href)
-    this._options = { agent: options?.agent }
+    this._options = { agent: options?.agent, headers: options?.headers }
     this._timeoutDuration =
       typeof options?.timeoutDuration === 'number' ? options?.timeoutDuration : 5000
     this._cooldownDuration =

--- a/src/jwks/remote.ts
+++ b/src/jwks/remote.ts
@@ -1,7 +1,9 @@
-import { isCloudflareWorkers } from '../runtime/env.js'
 import fetchJwks from '../runtime/fetch_jwks.js'
-import type { FlattenedJWSInput, GetKeyFunction, JWSHeaderParameters, KeyLike } from '../types.d'
+import { isCloudflareWorkers } from '../runtime/env.js'
+
+import type { KeyLike, JWSHeaderParameters, FlattenedJWSInput, GetKeyFunction } from '../types.d'
 import { JWKSInvalid, JWKSNoMatchingKey } from '../util/errors.js'
+
 import { isJWKSLike, LocalJWKSet } from './local.js'
 
 /**

--- a/src/runtime/browser/fetch_jwks.ts
+++ b/src/runtime/browser/fetch_jwks.ts
@@ -22,7 +22,7 @@ const fetchJwks: FetchFunction = async (
   const response = await fetch(url.href, {
     signal: controller ? controller.signal : undefined,
     redirect: 'manual',
-    headers: options.headers
+    headers: options.headers,
   }).catch((err) => {
     if (timedOut) throw new JWKSTimeout()
     throw err

--- a/src/runtime/browser/fetch_jwks.ts
+++ b/src/runtime/browser/fetch_jwks.ts
@@ -1,7 +1,13 @@
 import type { FetchFunction } from '../interfaces.d'
 import { JOSEError, JWKSTimeout } from '../../util/errors.js'
 
-const fetchJwks: FetchFunction = async (url: URL, timeout: number) => {
+type AcceptedRequestOptions = Pick<RequestInit, 'headers'>
+
+const fetchJwks: FetchFunction = async (
+  url: URL,
+  timeout: number,
+  options: AcceptedRequestOptions,
+) => {
   let controller!: AbortController
   let id!: ReturnType<typeof setTimeout>
   let timedOut = false
@@ -16,6 +22,7 @@ const fetchJwks: FetchFunction = async (url: URL, timeout: number) => {
   const response = await fetch(url.href, {
     signal: controller ? controller.signal : undefined,
     redirect: 'manual',
+    headers: options.headers
   }).catch((err) => {
     if (timedOut) throw new JWKSTimeout()
     throw err

--- a/src/runtime/node/fetch_jwks.ts
+++ b/src/runtime/node/fetch_jwks.ts
@@ -1,14 +1,13 @@
-import * as http from 'http'
-import * as https from 'https'
 import { once } from 'events'
 import type { ClientRequest, IncomingMessage } from 'http'
+import * as http from 'http'
 import type { RequestOptions } from 'https'
-
-import type { FetchFunction } from '../interfaces.d'
-import { JOSEError, JWKSTimeout } from '../../util/errors.js'
+import * as https from 'https'
 import { concat, decoder } from '../../lib/buffer_utils.js'
+import { JOSEError, JWKSTimeout } from '../../util/errors.js'
+import type { FetchFunction } from '../interfaces.d'
 
-type AcceptedRequestOptions = Pick<RequestOptions, 'agent'>
+type AcceptedRequestOptions = Pick<RequestOptions, 'agent' | 'headers'>
 
 const fetchJwks: FetchFunction = async (
   url: URL,
@@ -27,10 +26,11 @@ const fetchJwks: FetchFunction = async (
       throw new TypeError('Unsupported URL protocol.')
   }
 
-  const { agent } = options
+  const { agent, headers } = options
   const req = get(url.href, {
     agent,
     timeout,
+    headers,
   })
 
   const [response] = <[IncomingMessage]>(

--- a/src/runtime/node/fetch_jwks.ts
+++ b/src/runtime/node/fetch_jwks.ts
@@ -1,11 +1,12 @@
+import * as http from 'http'
+import * as https from 'https'
 import { once } from 'events'
 import type { ClientRequest, IncomingMessage } from 'http'
-import * as http from 'http'
 import type { RequestOptions } from 'https'
-import * as https from 'https'
-import { concat, decoder } from '../../lib/buffer_utils.js'
-import { JOSEError, JWKSTimeout } from '../../util/errors.js'
+
 import type { FetchFunction } from '../interfaces.d'
+import { JOSEError, JWKSTimeout } from '../../util/errors.js'
+import { concat, decoder } from '../../lib/buffer_utils.js'
 
 type AcceptedRequestOptions = Pick<RequestOptions, 'agent' | 'headers'>
 

--- a/test/jwks/remote.test.mjs
+++ b/test/jwks/remote.test.mjs
@@ -363,7 +363,7 @@ skipOnUndiciTestSerial('throws on invalid JWKSet', async (t) => {
 })
 
 skipOnUndiciTestSerial('can have headers configured', async (t) => {
-  nock('https://as.example.com', {
+  const scope = nock('https://as.example.com', {
     reqheaders: {
       'x-custom': 'foo',
     },
@@ -375,7 +375,7 @@ skipOnUndiciTestSerial('can have headers configured', async (t) => {
   const url = new URL('https://as.example.com/jwks')
   const JWKS = createRemoteJWKSet(url, { headers: { 'x-custom': 'foo' } })
   await JWKS().catch(() => {})
-  t.pass()
+  t.true(scope.isDone())
 })
 
 skipOnUndiciTest('handles ENOTFOUND', async (t) => {

--- a/test/jwks/remote.test.mjs
+++ b/test/jwks/remote.test.mjs
@@ -362,6 +362,22 @@ skipOnUndiciTestSerial('throws on invalid JWKSet', async (t) => {
   })
 })
 
+skipOnUndiciTestSerial('can have headers configured', async (t) => {
+  nock('https://as.example.com', {
+    reqheaders: {
+      'x-custom': 'foo',
+    },
+  })
+    .get('/jwks')
+    .once()
+    .reply(200, 'null')
+
+  const url = new URL('https://as.example.com/jwks')
+  const JWKS = createRemoteJWKSet(url, { headers: { 'x-custom': 'foo' } })
+  await JWKS().catch(() => {})
+  t.pass()
+})
+
 skipOnUndiciTest('handles ENOTFOUND', async (t) => {
   nock.enableNetConnect()
   const url = new URL('https://op.example.com/jwks')


### PR DESCRIPTION
Similar to the `agent` option, this simply adds optional http headers to be sent with the fetch_wks http request.