### PR TITLE
feat: Add "worker" export in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   "exports": {
     ".": {
       "browser": "./dist/browser/index.js",
+      "worker": "./dist/browser/index.js",
       "import": "./dist/node/esm/index.js",
       "require": "./dist/node/cjs/index.js"
     },


### PR DESCRIPTION
To support setting the environment in esbuild to "worker" when building for cloudflare it cannot match the worker exports. Adding the "worker" export would resolve this.

Adding a "worker" export type is logical as the cloudflare environment has the same capabilities as a "worker like webworker serviceworker.