### PR TITLE
include types export for ts4.7 nodenext resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
       "browser": "./dist/browser/index.js",
       "worker": "./dist/browser/index.js",
       "import": "./dist/node/esm/index.js",
-      "require": "./dist/node/cjs/index.js"
+      "require": "./dist/node/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -79,11 +79,11 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "browser": "./dist/browser/index.js",
       "worker": "./dist/browser/index.js",
       "import": "./dist/node/esm/index.js",
-      "require": "./dist/node/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
+      "require": "./dist/node/cjs/index.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
See https://github.com/microsoft/TypeScript/issues/47792#issuecomment-1043819482

otherwise, building with nodenext resolution results in:

```
src/data-source/accessToken/jwt.ts:1:22 - error TS7016: Could not find a declaration file for module 'jose'. '/home/lizf/.yarn/berry/cache/jose-npm-4.8.0-c82ffaaa1e-9.zip/node_modules/jose/dist/node/esm/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/jose` if it exists or add a new declaration (.d.ts) file containing `declare module 'jose';`

1 import { jose } from "jose";
                       ~~~~~~
```