### PR TITLE
Catch TypeError

### DIFF
--- a/src/jwe/flattened/decrypt.ts
+++ b/src/jwe/flattened/decrypt.ts
@@ -118,8 +118,8 @@ export async function flattenedDecrypt(
 
   let parsedProt!: JWEHeaderParameters
   if (jwe.protected) {
-    const protectedHeader = base64url(jwe.protected)
     try {
+      const protectedHeader = base64url(jwe.protected)
       parsedProt = JSON.parse(decoder.decode(protectedHeader))
     } catch {
       throw new JWEInvalid('JWE Protected Header is invalid')

--- a/src/jws/flattened/verify.ts
+++ b/src/jws/flattened/verify.ts
@@ -100,8 +100,8 @@ export async function flattenedVerify(
 
   let parsedProt: JWSHeaderParameters = {}
   if (jws.protected) {
-    const protectedHeader = base64url(jws.protected)
     try {
+      const protectedHeader = base64url(jws.protected)
       parsedProt = JSON.parse(decoder.decode(protectedHeader))
     } catch {
       throw new JWSInvalid('JWS Protected Header is invalid')


### PR DESCRIPTION
Move definition of protectedHeader inside try block to catch TypeError('The input to be decoded is not correctly encoded.')