### PR TITLE
decode jwt without signature part

### DIFF
--- a/src/util/decode_jwt.ts
+++ b/src/util/decode_jwt.ts
@@ -23,11 +23,10 @@ export function decodeJwt(jwt: string) {
   if (typeof jwt !== 'string')
     throw new JWTInvalid('JWTs must use Compact JWS serialization, JWT must be a string')
 
-  const { 1: payload, length } = jwt.split('.')
+  const { 0: header, 1: payload, length } = jwt.split('.')
 
   if (length === 5) throw new JWTInvalid('Only JWTs using Compact JWS serialization can be decoded')
-  if (length !== 3) throw new JWTInvalid('Invalid JWT')
-  if (!payload) throw new JWTInvalid('JWTs must contain a payload')
+  if (!header && !payload) throw new JWTInvalid('JWTs must contain a header and a payload')
 
   let decoded: Uint8Array
   try {

--- a/test/util/decode_jwt.test.mjs
+++ b/test/util/decode_jwt.test.mjs
@@ -5,7 +5,7 @@ const { decodeJwt, errors, base64url } = await import(root)
 
 test('invalid inputs', (t) => {
   const jwt =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ'
 
   const parts = jwt.split('.')
 
@@ -19,32 +19,32 @@ test('invalid inputs', (t) => {
     message: 'Only JWTs using Compact JWS serialization can be decoded',
   })
 
-  t.throws(() => decodeJwt('.'), {
+  t.throws(() => decodeJwt([parts[0], ''].join('.')), {
     instanceOf: errors.JWTInvalid,
-    message: 'Invalid JWT',
+    message: 'JWTs must contain a header and a payload',
   })
 
-  t.throws(() => decodeJwt([parts[0], '', parts[2]].join('.')), {
+  t.throws(() => decodeJwt(['', parts[1]].join('.')), {
     instanceOf: errors.JWTInvalid,
-    message: 'JWTs must contain a payload',
+    message: 'JWTs must contain a header and a payload',
   })
 
-  t.throws(() => decodeJwt([parts[0], base64url.encode('null'), parts[2]].join('.')), {
-    instanceOf: errors.JWTInvalid,
-    message: 'Invalid JWT Claims Set',
-  })
-
-  t.throws(() => decodeJwt([parts[0], base64url.encode('[]'), parts[2]].join('.')), {
+  t.throws(() => decodeJwt([parts[0], base64url.encode('null')].join('.')), {
     instanceOf: errors.JWTInvalid,
     message: 'Invalid JWT Claims Set',
   })
 
-  t.throws(() => decodeJwt([parts[0], base64url.encode('{"notajson'), parts[2]].join('.')), {
+  t.throws(() => decodeJwt([parts[0], base64url.encode('[]')].join('.')), {
+    instanceOf: errors.JWTInvalid,
+    message: 'Invalid JWT Claims Set',
+  })
+
+  t.throws(() => decodeJwt([parts[0], base64url.encode('{"notajson')].join('.')), {
     instanceOf: errors.JWTInvalid,
     message: 'Failed to parse the decoded payload as JSON',
   })
 
-  t.deepEqual(decodeJwt([parts[0], base64url.encode('{}'), parts[2]].join('.')), {})
+  t.deepEqual(decodeJwt([parts[0], base64url.encode('{}')].join('.')), {})
 
   t.deepEqual(decodeJwt(jwt), {
     sub: '1234567890',


### PR DESCRIPTION
The changes proposed in this PR allows decodeJwt to process a token without signature part that, at the moment, return an Invalid JWT message.  

A common case when this problem occurs is when the jwt is split in two cookies : one with the header and the payload, and another with the signature.
The signature cookie is httpOnly and we can't rebuild the full jwt.  

I suggest that we can decode the payload without the signature like the debugger on [jwt.io](http://jwt.io/).