### PR TITLE
docs: avoid non-inclusive terminology

### DIFF
--- a/docs/functions/jwk_embedded.EmbeddedJWK.md
+++ b/docs/functions/jwk_embedded.EmbeddedJWK.md
@@ -7,7 +7,7 @@
 EmbeddedJWK is an implementation of a GetKeyFunction intended to be used with the JWS/JWT verify
 operations whenever you need to opt-in to verify signatures with a public key embedded in the
 token's "jwk" (JSON Web Key) Header Parameter. It is recommended to combine this with the verify
-algorithms option to create an allowlist of JWS algorithms to accept.
+function's `algorithms` option to define accepted JWS "alg" (Algorithm) Header Parameter values.
 
 **`example`** Usage
 

--- a/docs/functions/jwk_embedded.EmbeddedJWK.md
+++ b/docs/functions/jwk_embedded.EmbeddedJWK.md
@@ -7,7 +7,7 @@
 EmbeddedJWK is an implementation of a GetKeyFunction intended to be used with the JWS/JWT verify
 operations whenever you need to opt-in to verify signatures with a public key embedded in the
 token's "jwk" (JSON Web Key) Header Parameter. It is recommended to combine this with the verify
-algorithms option to whitelist JWS algorithms to accept.
+algorithms option to create an allowlist of JWS algorithms to accept.
 
 **`example`** Usage
 

--- a/src/jwk/embedded.ts
+++ b/src/jwk/embedded.ts
@@ -7,7 +7,7 @@ import { JWSInvalid } from '../util/errors.js'
  * EmbeddedJWK is an implementation of a GetKeyFunction intended to be used with the JWS/JWT verify
  * operations whenever you need to opt-in to verify signatures with a public key embedded in the
  * token's "jwk" (JSON Web Key) Header Parameter. It is recommended to combine this with the verify
- * algorithms option to create an allowlist of JWS algorithms to accept.
+ * function's `algorithms` option to define accepted JWS "alg" (Algorithm) Header Parameter values.
  *
  * @example Usage
  *

--- a/src/jwk/embedded.ts
+++ b/src/jwk/embedded.ts
@@ -7,7 +7,7 @@ import { JWSInvalid } from '../util/errors.js'
  * EmbeddedJWK is an implementation of a GetKeyFunction intended to be used with the JWS/JWT verify
  * operations whenever you need to opt-in to verify signatures with a public key embedded in the
  * token's "jwk" (JSON Web Key) Header Parameter. It is recommended to combine this with the verify
- * algorithms option to whitelist JWS algorithms to accept.
+ * algorithms option to create an allowlist of JWS algorithms to accept.
  *
  * @example Usage
  *


### PR DESCRIPTION
Updates a couple references from whitelist -> allowlist

https://developers.google.com/style/word-list#blacklist