### PR TITLE
Add missing '-' at end of PKCS#8 key example

### DIFF
--- a/docs/classes/jwt_sign.SignJWT.md
+++ b/docs/classes/jwt_sign.SignJWT.md
@@ -54,7 +54,7 @@ C5ayaqCqN1voWYUdGzxU2IA1E/5kVo5O8FesJeOhAoGBAImJbZFf+D5kA32Xxhac
 59lLWBCsocvvbd1cvDMNlRywAAyhsCb1SuX4nEAK9mrSBdfmoF2Nm3eilfsOds0f
 K5mX069IKG82CMqh3Mzptd7e7lyb9lsoGO0BAtjho3cWtha/UZ70vfaMzGuZ6JmQ
 ak6k+8+UFd93M4z0Qo74OhXB
------END PRIVATE KEY----`
+-----END PRIVATE KEY-----`
 const privateKey = await jose.importPKCS8(pkcs8, alg)
 
 const jwt = await new jose.SignJWT({ 'urn:example:claim': true })

--- a/src/jwt/sign.ts
+++ b/src/jwt/sign.ts
@@ -57,7 +57,7 @@ import { ProduceJWT } from './produce.js'
  * 59lLWBCsocvvbd1cvDMNlRywAAyhsCb1SuX4nEAK9mrSBdfmoF2Nm3eilfsOds0f
  * K5mX069IKG82CMqh3Mzptd7e7lyb9lsoGO0BAtjho3cWtha/UZ70vfaMzGuZ6JmQ
  * ak6k+8+UFd93M4z0Qo74OhXB
- * -----END PRIVATE KEY----`
+ * -----END PRIVATE KEY-----`
  * const privateKey = await jose.importPKCS8(pkcs8, alg)
  *
  * const jwt = await new jose.SignJWT({ 'urn:example:claim': true })


### PR DESCRIPTION
The regex replace at https://github.com/panva/jose/blob/0cd8ebafa062f8a29f6cdd9743e8c72ea04f8f0a/src/runtime/browser/asn1.ts#L174 rightly expects the "END PRIVATE KEY" to end with five "-", not four.