### PR TITLE
fix(typescript): export ProduceJWT as a class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export { jwtVerify } from './jwt/verify.js'
 export type { JWTVerifyOptions, JWTVerifyGetKey } from './jwt/verify.js'
 export { jwtDecrypt } from './jwt/decrypt.js'
 export type { JWTDecryptOptions, JWTDecryptGetKey } from './jwt/decrypt.js'
-export type { ProduceJWT } from './jwt/produce.js'
+export { ProduceJWT } from './jwt/produce.js'
 
 export { CompactEncrypt } from './jwe/compact/encrypt.js'
 export { FlattenedEncrypt } from './jwe/flattened/encrypt.js'


### PR DESCRIPTION
Hi there 👋

I want to extend this library to use Google Cloud KMS to sign JWT tokens.

Unfortunately, `ProduceJWT` is exported as a type, not a class in [src/index.ts](https://github.com/panva/jose/blob/main/src/index.ts#L21).

I wanted to use this class like as follows:
```ts
export class KMSSignJWT extends ProduceJWT {
  private _protectedHeader!: JWTHeaderParameters;

  /**
   * Sets the JWS Protected Header on the SignJWT object.
   *
   * @param protectedHeader JWS Protected Header. Must contain an "alg" (JWS Algorithm) property.
   */
  setProtectedHeader(protectedHeader: JWTHeaderParameters) {
    this._protectedHeader = protectedHeader;
    return this;
  }

  // ...
}
```
