### PR TITLE
refactor: catch type error when decoding base64url signature

### DIFF
--- a/src/jws/flattened/verify.ts
+++ b/src/jws/flattened/verify.ts
@@ -169,7 +169,12 @@ export async function flattenedVerify(
     encoder.encode('.'),
     typeof jws.payload === 'string' ? encoder.encode(jws.payload) : jws.payload,
   )
-  const signature = base64url(jws.signature)
+  try {
+    const signature = base64url(jws.signature)
+  }
+  catch (err) {
+    throw new JWSSignatureVerificationFailed()
+  }
   const verified = await verify(alg, key, signature, data)
 
   if (!verified) {

--- a/src/jws/flattened/verify.ts
+++ b/src/jws/flattened/verify.ts
@@ -171,8 +171,7 @@ export async function flattenedVerify(
   )
   try {
     const signature = base64url(jws.signature)
-  }
-  catch (err) {
+  } catch {
     throw new JWSSignatureVerificationFailed()
   }
   const verified = await verify(alg, key, signature, data)

--- a/src/jws/flattened/verify.ts
+++ b/src/jws/flattened/verify.ts
@@ -169,8 +169,9 @@ export async function flattenedVerify(
     encoder.encode('.'),
     typeof jws.payload === 'string' ? encoder.encode(jws.payload) : jws.payload,
   )
+  let signature: Uint8Array
   try {
-    const signature = base64url(jws.signature)
+    signature = base64url(jws.signature)
   } catch {
     throw new JWSInvalid('Failed to parse the base64url encoded signature')
   }

--- a/src/jws/flattened/verify.ts
+++ b/src/jws/flattened/verify.ts
@@ -172,7 +172,7 @@ export async function flattenedVerify(
   try {
     const signature = base64url(jws.signature)
   } catch {
-    throw new JWSSignatureVerificationFailed()
+    throw new JWSInvalid('Failed to parse the base64url encoded signature')
   }
   const verified = await verify(alg, key, signature, data)
 


### PR DESCRIPTION
When encountering a signature that cannot be decoded as base64, a type error is thrown. Ideally this should be caught and rethrown as a `JOSEError` so that error handling logic only needs to handle `JOSEError`s.