### PR TITLE
fix(types): export GetKeyFunction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,7 @@ export type {
   JWTHeaderParameters,
   JSONWebKeySet,
   CryptoRuntime,
+  GetKeyFunction,
 } from './types.d'
 
 export { default as cryptoRuntime } from './util/runtime.js'


### PR DESCRIPTION
GetKeyFunction type is not being re-exported to the index of types for the lib.

This is a fix for that.

Closes #591 