### PR TITLE
docs: adds jsdocs to timestamp helpers

### DIFF
--- a/docs/classes/jwt_encrypt.EncryptJWT.md
+++ b/docs/classes/jwt_encrypt.EncryptJWT.md
@@ -176,9 +176,9 @@ ___
 
 Set the "exp" (Expiration Time) Claim.
 
-- If a `number` is passed as an argument, it's used as the `exp` claim directly.
-- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
-  used as the claim.
+- If a `number` is passed as an argument it is used as the claim directly.
+- If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
+  claim.
 - If a `string` is passed as an argument it is resolved to a time span, and then added to the
   current unix timestamp and used as the claim.
 
@@ -235,10 +235,10 @@ ___
 
 Set the "iat" (Issued At) Claim.
 
-- If no argument is used the current unix timestamp is used as the `iat` claim.
-- If a `number` is passed as an argument, it's used as the `iat` claim directly.
-- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
-  used as the claim.
+- If no argument is used the current unix timestamp is used as the claim.
+- If a `number` is passed as an argument it is used as the claim directly.
+- If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
+  claim.
 - If a `string` is passed as an argument it is resolved to a time span, and then added to the
   current unix timestamp and used as the claim.
 
@@ -328,9 +328,9 @@ ___
 
 Set the "nbf" (Not Before) Claim.
 
-- If a `number` is passed as an argument, it's used as the claim directly.
-- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
-  used as the claim.
+- If a `number` is passed as an argument it is used as the claim directly.
+- If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
+  claim.
 - If a `string` is passed as an argument it is resolved to a time span, and then added to the
   current unix timestamp and used as the claim.
 

--- a/docs/classes/jwt_encrypt.EncryptJWT.md
+++ b/docs/classes/jwt_encrypt.EncryptJWT.md
@@ -176,11 +176,28 @@ ___
 
 Set the "exp" (Expiration Time) Claim.
 
+- If a `number` is passed as an argument, it's used as the `exp` claim directly.
+- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
+  used as the claim.
+- If a `string` is passed as an argument it is resolved to a time span, and then added to the
+  current unix timestamp and used as the claim.
+
+Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
+day".
+
+Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+"m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+"years", "yr", "yrs", and "y".
+
+If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
+subtracted from the current unix timestamp. A "from now" suffix can also be used for
+readability when adding to the current unix timestamp.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `input` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "exp" (Expiration Time) Claim value to set on the JWT Claims Set. When number is passed that is used as a value, when string is passed it is resolved to a time span and added to the current timestamp. |
+| `input` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "exp" (Expiration Time) Claim value to set on the JWT Claims Set. |
 
 #### Returns
 
@@ -218,11 +235,29 @@ ___
 
 Set the "iat" (Issued At) Claim.
 
+- If no argument is used the current unix timestamp is used as the `iat` claim.
+- If a `number` is passed as an argument, it's used as the `iat` claim directly.
+- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
+  used as the claim.
+- If a `string` is passed as an argument it is resolved to a time span, and then added to the
+  current unix timestamp and used as the claim.
+
+Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
+day".
+
+Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+"m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+"years", "yr", "yrs", and "y".
+
+If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
+subtracted from the current unix timestamp. A "from now" suffix can also be used for
+readability when adding to the current unix timestamp.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `input?` | `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "iat" (Issued At) Claim value to set on the JWT Claims Set. Default is current timestamp. |
+| `input?` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "iat" (Expiration Time) Claim value to set on the JWT Claims Set. |
 
 #### Returns
 
@@ -293,11 +328,28 @@ ___
 
 Set the "nbf" (Not Before) Claim.
 
+- If a `number` is passed as an argument, it's used as the claim directly.
+- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
+  used as the claim.
+- If a `string` is passed as an argument it is resolved to a time span, and then added to the
+  current unix timestamp and used as the claim.
+
+Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
+day".
+
+Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+"m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+"years", "yr", "yrs", and "y".
+
+If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
+subtracted from the current unix timestamp. A "from now" suffix can also be used for
+readability when adding to the current unix timestamp.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `input` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "nbf" (Not Before) Claim value to set on the JWT Claims Set. When number is passed that is used as a value, when string is passed it is resolved to a time span and added to the current timestamp. |
+| `input` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "nbf" (Not Before) Claim value to set on the JWT Claims Set. |
 
 #### Returns
 

--- a/docs/classes/jwt_encrypt.EncryptJWT.md
+++ b/docs/classes/jwt_encrypt.EncryptJWT.md
@@ -187,7 +187,8 @@ day".
 
 Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
 "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-"years", "yr", "yrs", and "y".
+"years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
+alias for a year.
 
 If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
 subtracted from the current unix timestamp. A "from now" suffix can also be used for
@@ -247,7 +248,8 @@ day".
 
 Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
 "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-"years", "yr", "yrs", and "y".
+"years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
+alias for a year.
 
 If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
 subtracted from the current unix timestamp. A "from now" suffix can also be used for
@@ -339,7 +341,8 @@ day".
 
 Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
 "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-"years", "yr", "yrs", and "y".
+"years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
+alias for a year.
 
 If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
 subtracted from the current unix timestamp. A "from now" suffix can also be used for

--- a/docs/classes/jwt_produce.ProduceJWT.md
+++ b/docs/classes/jwt_produce.ProduceJWT.md
@@ -62,9 +62,9 @@ ___
 
 Set the "exp" (Expiration Time) Claim.
 
-- If a `number` is passed as an argument, it's used as the `exp` claim directly.
-- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
-  used as the claim.
+- If a `number` is passed as an argument it is used as the claim directly.
+- If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
+  claim.
 - If a `string` is passed as an argument it is resolved to a time span, and then added to the
   current unix timestamp and used as the claim.
 
@@ -97,10 +97,10 @@ ___
 
 Set the "iat" (Issued At) Claim.
 
-- If no argument is used the current unix timestamp is used as the `iat` claim.
-- If a `number` is passed as an argument, it's used as the `iat` claim directly.
-- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
-  used as the claim.
+- If no argument is used the current unix timestamp is used as the claim.
+- If a `number` is passed as an argument it is used as the claim directly.
+- If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
+  claim.
 - If a `string` is passed as an argument it is resolved to a time span, and then added to the
   current unix timestamp and used as the claim.
 
@@ -169,9 +169,9 @@ ___
 
 Set the "nbf" (Not Before) Claim.
 
-- If a `number` is passed as an argument, it's used as the claim directly.
-- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
-  used as the claim.
+- If a `number` is passed as an argument it is used as the claim directly.
+- If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
+  claim.
 - If a `string` is passed as an argument it is resolved to a time span, and then added to the
   current unix timestamp and used as the claim.
 

--- a/docs/classes/jwt_produce.ProduceJWT.md
+++ b/docs/classes/jwt_produce.ProduceJWT.md
@@ -62,11 +62,28 @@ ___
 
 Set the "exp" (Expiration Time) Claim.
 
+- If a `number` is passed as an argument, it's used as the `exp` claim directly.
+- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
+  used as the claim.
+- If a `string` is passed as an argument it is resolved to a time span, and then added to the
+  current unix timestamp and used as the claim.
+
+Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
+day".
+
+Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+"m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+"years", "yr", "yrs", and "y".
+
+If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
+subtracted from the current unix timestamp. A "from now" suffix can also be used for
+readability when adding to the current unix timestamp.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `input` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "exp" (Expiration Time) Claim value to set on the JWT Claims Set. When number is passed that is used as a value, when string is passed it is resolved to a time span and added to the current timestamp. |
+| `input` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "exp" (Expiration Time) Claim value to set on the JWT Claims Set. |
 
 #### Returns
 
@@ -80,11 +97,29 @@ ___
 
 Set the "iat" (Issued At) Claim.
 
+- If no argument is used the current unix timestamp is used as the `iat` claim.
+- If a `number` is passed as an argument, it's used as the `iat` claim directly.
+- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
+  used as the claim.
+- If a `string` is passed as an argument it is resolved to a time span, and then added to the
+  current unix timestamp and used as the claim.
+
+Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
+day".
+
+Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+"m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+"years", "yr", "yrs", and "y".
+
+If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
+subtracted from the current unix timestamp. A "from now" suffix can also be used for
+readability when adding to the current unix timestamp.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `input?` | `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "iat" (Issued At) Claim value to set on the JWT Claims Set. Default is current timestamp. |
+| `input?` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "iat" (Expiration Time) Claim value to set on the JWT Claims Set. |
 
 #### Returns
 
@@ -134,11 +169,28 @@ ___
 
 Set the "nbf" (Not Before) Claim.
 
+- If a `number` is passed as an argument, it's used as the claim directly.
+- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
+  used as the claim.
+- If a `string` is passed as an argument it is resolved to a time span, and then added to the
+  current unix timestamp and used as the claim.
+
+Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
+day".
+
+Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+"m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+"years", "yr", "yrs", and "y".
+
+If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
+subtracted from the current unix timestamp. A "from now" suffix can also be used for
+readability when adding to the current unix timestamp.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `input` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "nbf" (Not Before) Claim value to set on the JWT Claims Set. When number is passed that is used as a value, when string is passed it is resolved to a time span and added to the current timestamp. |
+| `input` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "nbf" (Not Before) Claim value to set on the JWT Claims Set. |
 
 #### Returns
 

--- a/docs/classes/jwt_produce.ProduceJWT.md
+++ b/docs/classes/jwt_produce.ProduceJWT.md
@@ -73,7 +73,8 @@ day".
 
 Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
 "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-"years", "yr", "yrs", and "y".
+"years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
+alias for a year.
 
 If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
 subtracted from the current unix timestamp. A "from now" suffix can also be used for
@@ -109,7 +110,8 @@ day".
 
 Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
 "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-"years", "yr", "yrs", and "y".
+"years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
+alias for a year.
 
 If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
 subtracted from the current unix timestamp. A "from now" suffix can also be used for
@@ -180,7 +182,8 @@ day".
 
 Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
 "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-"years", "yr", "yrs", and "y".
+"years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
+alias for a year.
 
 If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
 subtracted from the current unix timestamp. A "from now" suffix can also be used for

--- a/docs/classes/jwt_sign.SignJWT.md
+++ b/docs/classes/jwt_sign.SignJWT.md
@@ -162,9 +162,9 @@ ___
 
 Set the "exp" (Expiration Time) Claim.
 
-- If a `number` is passed as an argument, it's used as the `exp` claim directly.
-- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
-  used as the claim.
+- If a `number` is passed as an argument it is used as the claim directly.
+- If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
+  claim.
 - If a `string` is passed as an argument it is resolved to a time span, and then added to the
   current unix timestamp and used as the claim.
 
@@ -197,10 +197,10 @@ ___
 
 Set the "iat" (Issued At) Claim.
 
-- If no argument is used the current unix timestamp is used as the `iat` claim.
-- If a `number` is passed as an argument, it's used as the `iat` claim directly.
-- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
-  used as the claim.
+- If no argument is used the current unix timestamp is used as the claim.
+- If a `number` is passed as an argument it is used as the claim directly.
+- If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
+  claim.
 - If a `string` is passed as an argument it is resolved to a time span, and then added to the
   current unix timestamp and used as the claim.
 
@@ -269,9 +269,9 @@ ___
 
 Set the "nbf" (Not Before) Claim.
 
-- If a `number` is passed as an argument, it's used as the claim directly.
-- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
-  used as the claim.
+- If a `number` is passed as an argument it is used as the claim directly.
+- If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
+  claim.
 - If a `string` is passed as an argument it is resolved to a time span, and then added to the
   current unix timestamp and used as the claim.
 

--- a/docs/classes/jwt_sign.SignJWT.md
+++ b/docs/classes/jwt_sign.SignJWT.md
@@ -173,7 +173,8 @@ day".
 
 Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
 "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-"years", "yr", "yrs", and "y".
+"years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
+alias for a year.
 
 If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
 subtracted from the current unix timestamp. A "from now" suffix can also be used for
@@ -209,7 +210,8 @@ day".
 
 Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
 "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-"years", "yr", "yrs", and "y".
+"years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
+alias for a year.
 
 If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
 subtracted from the current unix timestamp. A "from now" suffix can also be used for
@@ -280,7 +282,8 @@ day".
 
 Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
 "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-"years", "yr", "yrs", and "y".
+"years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
+alias for a year.
 
 If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
 subtracted from the current unix timestamp. A "from now" suffix can also be used for

--- a/docs/classes/jwt_sign.SignJWT.md
+++ b/docs/classes/jwt_sign.SignJWT.md
@@ -162,11 +162,28 @@ ___
 
 Set the "exp" (Expiration Time) Claim.
 
+- If a `number` is passed as an argument, it's used as the `exp` claim directly.
+- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
+  used as the claim.
+- If a `string` is passed as an argument it is resolved to a time span, and then added to the
+  current unix timestamp and used as the claim.
+
+Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
+day".
+
+Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+"m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+"years", "yr", "yrs", and "y".
+
+If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
+subtracted from the current unix timestamp. A "from now" suffix can also be used for
+readability when adding to the current unix timestamp.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `input` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "exp" (Expiration Time) Claim value to set on the JWT Claims Set. When number is passed that is used as a value, when string is passed it is resolved to a time span and added to the current timestamp. |
+| `input` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "exp" (Expiration Time) Claim value to set on the JWT Claims Set. |
 
 #### Returns
 
@@ -180,11 +197,29 @@ ___
 
 Set the "iat" (Issued At) Claim.
 
+- If no argument is used the current unix timestamp is used as the `iat` claim.
+- If a `number` is passed as an argument, it's used as the `iat` claim directly.
+- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
+  used as the claim.
+- If a `string` is passed as an argument it is resolved to a time span, and then added to the
+  current unix timestamp and used as the claim.
+
+Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
+day".
+
+Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+"m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+"years", "yr", "yrs", and "y".
+
+If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
+subtracted from the current unix timestamp. A "from now" suffix can also be used for
+readability when adding to the current unix timestamp.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `input?` | `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "iat" (Issued At) Claim value to set on the JWT Claims Set. Default is current timestamp. |
+| `input?` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "iat" (Expiration Time) Claim value to set on the JWT Claims Set. |
 
 #### Returns
 
@@ -234,11 +269,28 @@ ___
 
 Set the "nbf" (Not Before) Claim.
 
+- If a `number` is passed as an argument, it's used as the claim directly.
+- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
+  used as the claim.
+- If a `string` is passed as an argument it is resolved to a time span, and then added to the
+  current unix timestamp and used as the claim.
+
+Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
+day".
+
+Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+"m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+"years", "yr", "yrs", and "y".
+
+If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
+subtracted from the current unix timestamp. A "from now" suffix can also be used for
+readability when adding to the current unix timestamp.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `input` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "nbf" (Not Before) Claim value to set on the JWT Claims Set. When number is passed that is used as a value, when string is passed it is resolved to a time span and added to the current timestamp. |
+| `input` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "nbf" (Not Before) Claim value to set on the JWT Claims Set. |
 
 #### Returns
 

--- a/docs/classes/jwt_unsecured.UnsecuredJWT.md
+++ b/docs/classes/jwt_unsecured.UnsecuredJWT.md
@@ -129,9 +129,9 @@ ___
 
 Set the "exp" (Expiration Time) Claim.
 
-- If a `number` is passed as an argument, it's used as the `exp` claim directly.
-- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
-  used as the claim.
+- If a `number` is passed as an argument it is used as the claim directly.
+- If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
+  claim.
 - If a `string` is passed as an argument it is resolved to a time span, and then added to the
   current unix timestamp and used as the claim.
 
@@ -164,10 +164,10 @@ ___
 
 Set the "iat" (Issued At) Claim.
 
-- If no argument is used the current unix timestamp is used as the `iat` claim.
-- If a `number` is passed as an argument, it's used as the `iat` claim directly.
-- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
-  used as the claim.
+- If no argument is used the current unix timestamp is used as the claim.
+- If a `number` is passed as an argument it is used as the claim directly.
+- If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
+  claim.
 - If a `string` is passed as an argument it is resolved to a time span, and then added to the
   current unix timestamp and used as the claim.
 
@@ -236,9 +236,9 @@ ___
 
 Set the "nbf" (Not Before) Claim.
 
-- If a `number` is passed as an argument, it's used as the claim directly.
-- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
-  used as the claim.
+- If a `number` is passed as an argument it is used as the claim directly.
+- If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
+  claim.
 - If a `string` is passed as an argument it is resolved to a time span, and then added to the
   current unix timestamp and used as the claim.
 

--- a/docs/classes/jwt_unsecured.UnsecuredJWT.md
+++ b/docs/classes/jwt_unsecured.UnsecuredJWT.md
@@ -129,11 +129,28 @@ ___
 
 Set the "exp" (Expiration Time) Claim.
 
+- If a `number` is passed as an argument, it's used as the `exp` claim directly.
+- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
+  used as the claim.
+- If a `string` is passed as an argument it is resolved to a time span, and then added to the
+  current unix timestamp and used as the claim.
+
+Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
+day".
+
+Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+"m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+"years", "yr", "yrs", and "y".
+
+If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
+subtracted from the current unix timestamp. A "from now" suffix can also be used for
+readability when adding to the current unix timestamp.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `input` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "exp" (Expiration Time) Claim value to set on the JWT Claims Set. When number is passed that is used as a value, when string is passed it is resolved to a time span and added to the current timestamp. |
+| `input` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "exp" (Expiration Time) Claim value to set on the JWT Claims Set. |
 
 #### Returns
 
@@ -147,11 +164,29 @@ ___
 
 Set the "iat" (Issued At) Claim.
 
+- If no argument is used the current unix timestamp is used as the `iat` claim.
+- If a `number` is passed as an argument, it's used as the `iat` claim directly.
+- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
+  used as the claim.
+- If a `string` is passed as an argument it is resolved to a time span, and then added to the
+  current unix timestamp and used as the claim.
+
+Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
+day".
+
+Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+"m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+"years", "yr", "yrs", and "y".
+
+If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
+subtracted from the current unix timestamp. A "from now" suffix can also be used for
+readability when adding to the current unix timestamp.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `input?` | `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "iat" (Issued At) Claim value to set on the JWT Claims Set. Default is current timestamp. |
+| `input?` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "iat" (Expiration Time) Claim value to set on the JWT Claims Set. |
 
 #### Returns
 
@@ -201,11 +236,28 @@ ___
 
 Set the "nbf" (Not Before) Claim.
 
+- If a `number` is passed as an argument, it's used as the claim directly.
+- If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
+  used as the claim.
+- If a `string` is passed as an argument it is resolved to a time span, and then added to the
+  current unix timestamp and used as the claim.
+
+Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
+day".
+
+Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+"m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+"years", "yr", "yrs", and "y".
+
+If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
+subtracted from the current unix timestamp. A "from now" suffix can also be used for
+readability when adding to the current unix timestamp.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `input` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "nbf" (Not Before) Claim value to set on the JWT Claims Set. When number is passed that is used as a value, when string is passed it is resolved to a time span and added to the current timestamp. |
+| `input` | `string` \| `number` \| [`Date`]( https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date ) | "nbf" (Not Before) Claim value to set on the JWT Claims Set. |
 
 #### Returns
 

--- a/docs/classes/jwt_unsecured.UnsecuredJWT.md
+++ b/docs/classes/jwt_unsecured.UnsecuredJWT.md
@@ -140,7 +140,8 @@ day".
 
 Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
 "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-"years", "yr", "yrs", and "y".
+"years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
+alias for a year.
 
 If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
 subtracted from the current unix timestamp. A "from now" suffix can also be used for
@@ -176,7 +177,8 @@ day".
 
 Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
 "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-"years", "yr", "yrs", and "y".
+"years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
+alias for a year.
 
 If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
 subtracted from the current unix timestamp. A "from now" suffix can also be used for
@@ -247,7 +249,8 @@ day".
 
 Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
 "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-"years", "yr", "yrs", and "y".
+"years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
+alias for a year.
 
 If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
 subtracted from the current unix timestamp. A "from now" suffix can also be used for

--- a/src/jwt/produce.ts
+++ b/src/jwt/produce.ts
@@ -77,7 +77,8 @@ export class ProduceJWT {
    *
    * Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
    * "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-   * "years", "yr", "yrs", and "y".
+   * "years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
+   * alias for a year.
    *
    * If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
    * subtracted from the current unix timestamp. A "from now" suffix can also be used for
@@ -110,7 +111,8 @@ export class ProduceJWT {
    *
    * Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
    * "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-   * "years", "yr", "yrs", and "y".
+   * "years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
+   * alias for a year.
    *
    * If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
    * subtracted from the current unix timestamp. A "from now" suffix can also be used for
@@ -144,7 +146,8 @@ export class ProduceJWT {
    *
    * Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
    * "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-   * "years", "yr", "yrs", and "y".
+   * "years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
+   * alias for a year.
    *
    * If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
    * subtracted from the current unix timestamp. A "from now" suffix can also be used for

--- a/src/jwt/produce.ts
+++ b/src/jwt/produce.ts
@@ -66,9 +66,9 @@ export class ProduceJWT {
   /**
    * Set the "nbf" (Not Before) Claim.
    *
-   * - If a `number` is passed as an argument, it's used as the claim directly.
-   * - If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
-   *   used as the claim.
+   * - If a `number` is passed as an argument it is used as the claim directly.
+   * - If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
+   *   claim.
    * - If a `string` is passed as an argument it is resolved to a time span, and then added to the
    *   current unix timestamp and used as the claim.
    *
@@ -99,9 +99,9 @@ export class ProduceJWT {
   /**
    * Set the "exp" (Expiration Time) Claim.
    *
-   * - If a `number` is passed as an argument, it's used as the `exp` claim directly.
-   * - If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
-   *   used as the claim.
+   * - If a `number` is passed as an argument it is used as the claim directly.
+   * - If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
+   *   claim.
    * - If a `string` is passed as an argument it is resolved to a time span, and then added to the
    *   current unix timestamp and used as the claim.
    *
@@ -132,10 +132,10 @@ export class ProduceJWT {
   /**
    * Set the "iat" (Issued At) Claim.
    *
-   * - If no argument is used the current unix timestamp is used as the `iat` claim.
-   * - If a `number` is passed as an argument, it's used as the `iat` claim directly.
-   * - If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
-   *   used as the claim.
+   * - If no argument is used the current unix timestamp is used as the claim.
+   * - If a `number` is passed as an argument it is used as the claim directly.
+   * - If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
+   *   claim.
    * - If a `string` is passed as an argument it is resolved to a time span, and then added to the
    *   current unix timestamp and used as the claim.
    *

--- a/src/jwt/produce.ts
+++ b/src/jwt/produce.ts
@@ -66,20 +66,23 @@ export class ProduceJWT {
   /**
    * Set the "nbf" (Not Before) Claim.
    *
-   * @param input "nbf" (Not Before) Claim value to set on the JWT Claims Set. 
-   *   
+   * @param input "nbf" (Not Before) Claim value to set on the JWT Claims Set.
+   *
    *   - If a `number` is passed as an argument, it's used as the `nbf` claim directly.
-   *   
-   *   - If a `Date` instance is passed, the value is converted to unix timestamp and used as `nbf` claim.
-   *   
-   *   - If a `string` is passed it is resolved to a time span, and then added to the current unix timestamp.
-   *   
+   *   - If a `Date` instance is passed, the value is converted to unix timestamp and used as `nbf`
+   *       claim.
+   *   - If a `string` is passed it is resolved to a time span, and then added to the current unix
+   *       timestamp.
+   *
    *   Format used for timespan should be a number followed by a unit, such as "5 minutes" or "1 day".
-   * 
-   *   Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins", "m",
-   *   "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year", "years", "y".
-   *   
-   *   If the string is suffixed with "ago", or prefixed with a "-", the resulting timespan gets subtracted from the current unix timestamp. A "from now" suffix can also be used for readability when adding to the current unix timestamp.
+   *
+   *   Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+   *   "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+   *   "years", "yr", "yrs", and "y".
+   *
+   *   If the string is suffixed with "ago", or prefixed with a "-", the resulting timespan gets
+   *   subtracted from the current unix timestamp. A "from now" suffix can also be used for
+   *   readability when adding to the current unix timestamp.
    */
   setNotBefore(input: number | string | Date) {
     if (typeof input === 'number') {
@@ -93,22 +96,25 @@ export class ProduceJWT {
   }
 
   /**
-   * Set the `exp` (Expiration Time) Claim.
-   * 
-   * @param input "exp" (Expiration Time) Claim value to set on the JWT Claims Set. 
-   *   
+   * Set the "exp" (Expiration Time) Claim.
+   *
+   * @param input "exp" (Expiration Time) Claim value to set on the JWT Claims Set.
+   *
    *   - If a `number` is passed as an argument, it's used as the `exp` claim directly.
-   *   
-   *   - If a `Date` instance is passed, the value is converted to unix timestamp and used as `exp` claim.
-   *   
-   *   - If a `string` is passed it is resolved to a time span, and then added to the current unix timestamp.
-   *   
+   *   - If a `Date` instance is passed, the value is converted to unix timestamp and used as `exp`
+   *       claim.
+   *   - If a `string` is passed it is resolved to a time span, and then added to the current unix
+   *       timestamp.
+   *
    *   Format used for timespan should be a number followed by a unit, such as "5 minutes" or "1 day".
-   * 
-   *   Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins", "m",
-   *   "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year", "years", "y".
-   *   
-   *   If the string is suffixed with "ago", or prefixed with a "-", the resulting timespan gets subtracted from the current unix timestamp. A "from now" suffix can also be used for readability when adding to the current unix timestamp.
+   *
+   *   Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+   *   "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+   *   "years", "yr", "yrs", and "y".
+   *
+   *   If the string is suffixed with "ago", or prefixed with a "-", the resulting timespan gets
+   *   subtracted from the current unix timestamp. A "from now" suffix can also be used for
+   *   readability when adding to the current unix timestamp.
    */
   setExpirationTime(input: number | string | Date) {
     if (typeof input === 'number') {
@@ -124,21 +130,24 @@ export class ProduceJWT {
   /**
    * Set the "iat" (Issued At) Claim.
    *
-   * @param input "iat" (Expiration Time) Claim value to set on the JWT Claims Set. 
-   *   - If no argument is used the current unix timestamp is used as the `iat` claim.
+   * @param input "iat" (Expiration Time) Claim value to set on the JWT Claims Set.
    *
+   *   - If no argument is used the current unix timestamp is used as the `iat` claim.
    *   - If a `number` is passed as an argument, it's used as the `iat` claim directly.
-   *   
-   *   - If a `Date` instance is passed, the value is converted to unix timestamp and used as `iat` claim.
-   *   
-   *   - If a `string` is passed it is resolved to a time span, and then added to the current unix timestamp.
-   *   
+   *   - If a `Date` instance is passed, the value is converted to unix timestamp and used as `iat`
+   *       claim.
+   *   - If a `string` is passed it is resolved to a time span, and then added to the current unix
+   *       timestamp.
+   *
    *   Format used for timespan should be a number followed by a unit, such as "5 minutes" or "1 day".
-   * 
-   *   Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins", "m",
-   *   "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year", "years", "y".
-   *   
-   *   If the string is suffixed with "ago", or prefixed with a "-", the resulting timespan gets subtracted from the current unix timestamp. A "from now" suffix can also be used for readability when adding to the current unix timestamp.
+   *
+   *   Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+   *   "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+   *   "years", "yr", "yrs", and "y".
+   *
+   *   If the string is suffixed with "ago", or prefixed with a "-", the resulting timespan gets
+   *   subtracted from the current unix timestamp. A "from now" suffix can also be used for
+   *   readability when adding to the current unix timestamp.
    */
   setIssuedAt(input?: number | string | Date) {
     if (typeof input === 'undefined') {

--- a/src/jwt/produce.ts
+++ b/src/jwt/produce.ts
@@ -66,23 +66,24 @@ export class ProduceJWT {
   /**
    * Set the "nbf" (Not Before) Claim.
    *
+   * - If a `number` is passed as an argument, it's used as the claim directly.
+   * - If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
+   *   used as the claim.
+   * - If a `string` is passed as an argument it is resolved to a time span, and then added to the
+   *   current unix timestamp and used as the claim.
+   *
+   * Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
+   * day".
+   *
+   * Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+   * "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+   * "years", "yr", "yrs", and "y".
+   *
+   * If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
+   * subtracted from the current unix timestamp. A "from now" suffix can also be used for
+   * readability when adding to the current unix timestamp.
+   *
    * @param input "nbf" (Not Before) Claim value to set on the JWT Claims Set.
-   *
-   *   - If a `number` is passed as an argument, it's used as the `nbf` claim directly.
-   *   - If a `Date` instance is passed, the value is converted to unix timestamp and used as `nbf`
-   *       claim.
-   *   - If a `string` is passed it is resolved to a time span, and then added to the current unix
-   *       timestamp.
-   *
-   *   Format used for timespan should be a number followed by a unit, such as "5 minutes" or "1 day".
-   *
-   *   Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
-   *   "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-   *   "years", "yr", "yrs", and "y".
-   *
-   *   If the string is suffixed with "ago", or prefixed with a "-", the resulting timespan gets
-   *   subtracted from the current unix timestamp. A "from now" suffix can also be used for
-   *   readability when adding to the current unix timestamp.
    */
   setNotBefore(input: number | string | Date) {
     if (typeof input === 'number') {
@@ -98,23 +99,24 @@ export class ProduceJWT {
   /**
    * Set the "exp" (Expiration Time) Claim.
    *
+   * - If a `number` is passed as an argument, it's used as the `exp` claim directly.
+   * - If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
+   *   used as the claim.
+   * - If a `string` is passed as an argument it is resolved to a time span, and then added to the
+   *   current unix timestamp and used as the claim.
+   *
+   * Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
+   * day".
+   *
+   * Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+   * "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+   * "years", "yr", "yrs", and "y".
+   *
+   * If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
+   * subtracted from the current unix timestamp. A "from now" suffix can also be used for
+   * readability when adding to the current unix timestamp.
+   *
    * @param input "exp" (Expiration Time) Claim value to set on the JWT Claims Set.
-   *
-   *   - If a `number` is passed as an argument, it's used as the `exp` claim directly.
-   *   - If a `Date` instance is passed, the value is converted to unix timestamp and used as `exp`
-   *       claim.
-   *   - If a `string` is passed it is resolved to a time span, and then added to the current unix
-   *       timestamp.
-   *
-   *   Format used for timespan should be a number followed by a unit, such as "5 minutes" or "1 day".
-   *
-   *   Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
-   *   "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-   *   "years", "yr", "yrs", and "y".
-   *
-   *   If the string is suffixed with "ago", or prefixed with a "-", the resulting timespan gets
-   *   subtracted from the current unix timestamp. A "from now" suffix can also be used for
-   *   readability when adding to the current unix timestamp.
    */
   setExpirationTime(input: number | string | Date) {
     if (typeof input === 'number') {
@@ -130,24 +132,25 @@ export class ProduceJWT {
   /**
    * Set the "iat" (Issued At) Claim.
    *
+   * - If no argument is used the current unix timestamp is used as the `iat` claim.
+   * - If a `number` is passed as an argument, it's used as the `iat` claim directly.
+   * - If a `Date` instance is passed as an argument, the value is converted to unix timestamp and
+   *   used as the claim.
+   * - If a `string` is passed as an argument it is resolved to a time span, and then added to the
+   *   current unix timestamp and used as the claim.
+   *
+   * Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
+   * day".
+   *
+   * Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+   * "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+   * "years", "yr", "yrs", and "y".
+   *
+   * If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
+   * subtracted from the current unix timestamp. A "from now" suffix can also be used for
+   * readability when adding to the current unix timestamp.
+   *
    * @param input "iat" (Expiration Time) Claim value to set on the JWT Claims Set.
-   *
-   *   - If no argument is used the current unix timestamp is used as the `iat` claim.
-   *   - If a `number` is passed as an argument, it's used as the `iat` claim directly.
-   *   - If a `Date` instance is passed, the value is converted to unix timestamp and used as `iat`
-   *       claim.
-   *   - If a `string` is passed it is resolved to a time span, and then added to the current unix
-   *       timestamp.
-   *
-   *   Format used for timespan should be a number followed by a unit, such as "5 minutes" or "1 day".
-   *
-   *   Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
-   *   "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
-   *   "years", "yr", "yrs", and "y".
-   *
-   *   If the string is suffixed with "ago", or prefixed with a "-", the resulting timespan gets
-   *   subtracted from the current unix timestamp. A "from now" suffix can also be used for
-   *   readability when adding to the current unix timestamp.
    */
   setIssuedAt(input?: number | string | Date) {
     if (typeof input === 'undefined') {

--- a/src/jwt/produce.ts
+++ b/src/jwt/produce.ts
@@ -79,7 +79,7 @@ export class ProduceJWT {
    *   Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins", "m",
    *   "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year", "years", "y".
    *   
-   *   If the string is suffixed with "ago", or prefixed with a "-", the resulting timespan gets subtracted from the current unix timestamp. A "from now" suffix can also be used for readability.
+   *   If the string is suffixed with "ago", or prefixed with a "-", the resulting timespan gets subtracted from the current unix timestamp. A "from now" suffix can also be used for readability when adding to the current unix timestamp.
    */
   setNotBefore(input: number | string | Date) {
     if (typeof input === 'number') {
@@ -108,7 +108,7 @@ export class ProduceJWT {
    *   Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins", "m",
    *   "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year", "years", "y".
    *   
-   *   If the string is suffixed with "ago", or prefixed with a "-", the resulting timespan gets subtracted from the current unix timestamp. A "from now" suffix can also be used for readability.
+   *   If the string is suffixed with "ago", or prefixed with a "-", the resulting timespan gets subtracted from the current unix timestamp. A "from now" suffix can also be used for readability when adding to the current unix timestamp.
    */
   setExpirationTime(input: number | string | Date) {
     if (typeof input === 'number') {
@@ -138,7 +138,7 @@ export class ProduceJWT {
    *   Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins", "m",
    *   "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year", "years", "y".
    *   
-   *   If the string is suffixed with "ago", or prefixed with a "-", the resulting timespan gets subtracted from the current unix timestamp. A "from now" suffix can also be used for readability.
+   *   If the string is suffixed with "ago", or prefixed with a "-", the resulting timespan gets subtracted from the current unix timestamp. A "from now" suffix can also be used for readability when adding to the current unix timestamp.
    */
   setIssuedAt(input?: number | string | Date) {
     if (typeof input === 'undefined') {

--- a/src/jwt/produce.ts
+++ b/src/jwt/produce.ts
@@ -70,7 +70,7 @@ export class ProduceJWT {
    *   
    *   - If a `number` is passed as an argument, it's used as the `nbf` claim directly.
    *   
-   *   - If a `Date` object is passed, the value is converted to unix timestamp and used as `nbf` claim.
+   *   - If a `Date` instance is passed, the value is converted to unix timestamp and used as `nbf` claim.
    *   
    *   - If a `string` is passed it is resolved to a time span, and then added to the current unix timestamp.
    *   
@@ -99,7 +99,7 @@ export class ProduceJWT {
    *   
    *   - If a `number` is passed as an argument, it's used as the `exp` claim directly.
    *   
-   *   - If a `Date` object is passed, the value is converted to unix timestamp and used as `exp` claim.
+   *   - If a `Date` instance is passed, the value is converted to unix timestamp and used as `exp` claim.
    *   
    *   - If a `string` is passed it is resolved to a time span, and then added to the current unix timestamp.
    *   
@@ -129,7 +129,7 @@ export class ProduceJWT {
    *
    *   - If a `number` is passed as an argument, it's used as the `iat` claim directly.
    *   
-   *   - If a `Date` object is passed, the value is converted to unix timestamp and used as `iat` claim.
+   *   - If a `Date` instance is passed, the value is converted to unix timestamp and used as `iat` claim.
    *   
    *   - If a `string` is passed it is resolved to a time span, and then added to the current unix timestamp.
    *   

--- a/src/jwt/produce.ts
+++ b/src/jwt/produce.ts
@@ -77,11 +77,9 @@ export class ProduceJWT {
    *   Format used for timespan should be a number followed by a unit, such as "5 minutes" or "1 day".
    * 
    *   Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins", "m",
-   *   "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year", "years".
+   *   "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year", "years", "y".
    *   
-   *   If the string is suffixed with "ago" or "from now", or prefixed with a "-", the resulting number of seconds gets subtracted from the current unix timestamp.
-   * 
-   * @throws {TypeError} When input string is in bad format or numeric input is infinite.
+   *   If the string is suffixed with "ago", or prefixed with a "-", the resulting timespan gets subtracted from the current unix timestamp. A "from now" suffix can also be used for readability.
    */
   setNotBefore(input: number | string | Date) {
     if (typeof input === 'number') {
@@ -108,11 +106,9 @@ export class ProduceJWT {
    *   Format used for timespan should be a number followed by a unit, such as "5 minutes" or "1 day".
    * 
    *   Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins", "m",
-   *   "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year", "years".
+   *   "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year", "years", "y".
    *   
-   *   If the string is suffixed with "ago" or "from now", or prefixed with a "-", the resulting number of seconds gets subtracted from the current unix timestamp.
-   * 
-   * @throws {TypeError} When input string is in bad format or numeric input is infinite.
+   *   If the string is suffixed with "ago", or prefixed with a "-", the resulting timespan gets subtracted from the current unix timestamp. A "from now" suffix can also be used for readability.
    */
   setExpirationTime(input: number | string | Date) {
     if (typeof input === 'number') {
@@ -129,7 +125,8 @@ export class ProduceJWT {
    * Set the "iat" (Issued At) Claim.
    *
    * @param input "iat" (Expiration Time) Claim value to set on the JWT Claims Set. 
-   *   
+   *   - If no argument is used the current unix timestamp is used as the `iat` claim.
+   *
    *   - If a `number` is passed as an argument, it's used as the `iat` claim directly.
    *   
    *   - If a `Date` object is passed, the value is converted to unix timestamp and used as `iat` claim.
@@ -139,11 +136,9 @@ export class ProduceJWT {
    *   Format used for timespan should be a number followed by a unit, such as "5 minutes" or "1 day".
    * 
    *   Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins", "m",
-   *   "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year", "years".
+   *   "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year", "years", "y".
    *   
-   *   If the string is suffixed with "ago" or "from now", or prefixed with a "-", the resulting number of seconds gets subtracted from the current unix timestamp.
-   * 
-   * @throws {TypeError} When input string is in bad format or numeric input is infinite.
+   *   If the string is suffixed with "ago", or prefixed with a "-", the resulting timespan gets subtracted from the current unix timestamp. A "from now" suffix can also be used for readability.
    */
   setIssuedAt(input?: number | string | Date) {
     if (typeof input === 'undefined') {

--- a/src/jwt/produce.ts
+++ b/src/jwt/produce.ts
@@ -66,9 +66,22 @@ export class ProduceJWT {
   /**
    * Set the "nbf" (Not Before) Claim.
    *
-   * @param input "nbf" (Not Before) Claim value to set on the JWT Claims Set. When number is passed
-   *   that is used as a value, when string is passed it is resolved to a time span and added to the
-   *   current timestamp.
+   * @param input "nbf" (Not Before) Claim value to set on the JWT Claims Set. 
+   *   
+   *   - If a `number` is passed as an argument, it's used as the `nbf` claim directly.
+   *   
+   *   - If a `Date` object is passed, the value is converted to unix timestamp and used as `nbf` claim.
+   *   
+   *   - If a `string` is passed it is resolved to a time span, and then added to the current unix timestamp.
+   *   
+   *   Format used for timespan should be a number followed by a unit, such as "5 minutes" or "1 day".
+   * 
+   *   Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins", "m",
+   *   "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year", "years".
+   *   
+   *   If the string is suffixed with "ago" or "from now", or prefixed with a "-", the resulting number of seconds gets subtracted from the current unix timestamp.
+   * 
+   * @throws {TypeError} When input string is in bad format or numeric input is infinite.
    */
   setNotBefore(input: number | string | Date) {
     if (typeof input === 'number') {
@@ -82,11 +95,24 @@ export class ProduceJWT {
   }
 
   /**
-   * Set the "exp" (Expiration Time) Claim.
-   *
-   * @param input "exp" (Expiration Time) Claim value to set on the JWT Claims Set. When number is
-   *   passed that is used as a value, when string is passed it is resolved to a time span and added
-   *   to the current timestamp.
+   * Set the `exp` (Expiration Time) Claim.
+   * 
+   * @param input "exp" (Expiration Time) Claim value to set on the JWT Claims Set. 
+   *   
+   *   - If a `number` is passed as an argument, it's used as the `exp` claim directly.
+   *   
+   *   - If a `Date` object is passed, the value is converted to unix timestamp and used as `exp` claim.
+   *   
+   *   - If a `string` is passed it is resolved to a time span, and then added to the current unix timestamp.
+   *   
+   *   Format used for timespan should be a number followed by a unit, such as "5 minutes" or "1 day".
+   * 
+   *   Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins", "m",
+   *   "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year", "years".
+   *   
+   *   If the string is suffixed with "ago" or "from now", or prefixed with a "-", the resulting number of seconds gets subtracted from the current unix timestamp.
+   * 
+   * @throws {TypeError} When input string is in bad format or numeric input is infinite.
    */
   setExpirationTime(input: number | string | Date) {
     if (typeof input === 'number') {
@@ -102,8 +128,22 @@ export class ProduceJWT {
   /**
    * Set the "iat" (Issued At) Claim.
    *
-   * @param input "iat" (Issued At) Claim value to set on the JWT Claims Set. Default is current
-   *   timestamp.
+   * @param input "iat" (Expiration Time) Claim value to set on the JWT Claims Set. 
+   *   
+   *   - If a `number` is passed as an argument, it's used as the `iat` claim directly.
+   *   
+   *   - If a `Date` object is passed, the value is converted to unix timestamp and used as `iat` claim.
+   *   
+   *   - If a `string` is passed it is resolved to a time span, and then added to the current unix timestamp.
+   *   
+   *   Format used for timespan should be a number followed by a unit, such as "5 minutes" or "1 day".
+   * 
+   *   Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins", "m",
+   *   "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year", "years".
+   *   
+   *   If the string is suffixed with "ago" or "from now", or prefixed with a "-", the resulting number of seconds gets subtracted from the current unix timestamp.
+   * 
+   * @throws {TypeError} When input string is in bad format or numeric input is infinite.
    */
   setIssuedAt(input?: number | string | Date) {
     if (typeof input === 'undefined') {


### PR DESCRIPTION
JSDoc like this gives me a nice idea on how to use an API and it doesn't have too much clutter imho.

![image](https://github.com/panva/jose/assets/11753867/fae1b837-d2e4-4b59-90e9-733079637ced)
