### PR TITLE
types: type overhaul

### DIFF
--- a/src/key/import.ts
+++ b/src/key/import.ts
@@ -4,7 +4,7 @@ import asKeyObject from '../runtime/jwk_to_key.js'
 
 import { JOSENotSupported } from '../util/errors.js'
 import isObject from '../lib/is_object.js'
-import type { JWK, KeyLike } from '../types.d'
+import type { JWK, KeyLike, CompactJWSHeaderParameters } from '../types.d'
 
 export interface PEMImportOptions {
   /**
@@ -168,7 +168,7 @@ export async function importPKCS8<KeyLikeType extends KeyLike = KeyLike>(
  */
 export async function importJWK<KeyLikeType extends KeyLike = KeyLike>(
   jwk: JWK,
-  alg?: string,
+  alg?: CompactJWSHeaderParameters["alg"],
 ): Promise<KeyLikeType | Uint8Array> {
   if (!isObject(jwk)) {
     throw new TypeError('JWK must be an object')

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -119,7 +119,7 @@ export interface JWK {
   /** JWK "kid" (Key ID) Parameter. */
   kid?: string
   /** JWK "kty" (Key Type) Parameter. */
-  kty?: string
+  kty?: 'RSA' | 'EC' | 'OKP' | 'oct'
   n?: string
   oth?: Array<{
     d?: string
@@ -263,7 +263,7 @@ export interface JoseHeaderParameters {
 /** Recognized JWS Header Parameters, any other Header Members may also be present. */
 export interface JWSHeaderParameters extends JoseHeaderParameters {
   /** JWS "alg" (Algorithm) Header Parameter. */
-  alg?: string
+  alg?: 'HS256' | 'HS384' | 'HS512' | 'RS256' | 'RS384' | 'RS512'| 'ES256' | 'ES384' | 'ES512' | 'PS256' | 'PS384' | 'PS512' | (string & {})
 
   /**
    * This JWS Extension Header Parameter modifies the JWS Payload representation and the JWS Signing
@@ -365,10 +365,10 @@ export interface GeneralJWE extends Omit<FlattenedJWE, 'encrypted_key' | 'header
 /** Recognized JWE Header Parameters, any other Header members may also be present. */
 export interface JWEHeaderParameters extends JoseHeaderParameters {
   /** JWE "alg" (Algorithm) Header Parameter. */
-  alg?: string
+  alg?: 'RSA-OAEP' | 'RSA-OAEP-256' | 'RSA1_5' | 'A128KW' | 'A192KW' | 'A256KW' | 'dir' | 'ECDH-ES' | 'ECDH-ES+A128KW' | 'ECDH-ES+A192KW' | 'ECDH-ES+A256KW' | 'A128GCMKW' | 'A192GCMKW' | 'A256GCMKW' | 'PBES2-HS256+A128KW' | 'PBES2-HS384+A192KW' | 'PBES2-HS512+A256KW' | (string & {})
 
   /** JWE "enc" (Encryption Algorithm) Header Parameter. */
-  enc?: string
+  enc?: 'A128CBC-HS256' | 'A192CBC-HS384' | 'A256CBC-HS512' | 'A128GCM' | 'A192GCM' | 'A256GCM' | (string & {})
 
   /** JWE "crit" (Critical) Header Parameter. */
   crit?: string[]
@@ -621,7 +621,7 @@ export interface ResolvedKey<KeyLikeType extends KeyLike = KeyLike> {
 
 /** Recognized Compact JWS Header Parameters, any other Header Members may also be present. */
 export interface CompactJWSHeaderParameters extends JWSHeaderParameters {
-  alg: string
+  alg: 'HS256' | 'HS384' | 'HS512' | 'RS256' | 'RS384' | 'RS512'| 'ES256' | 'ES384' | 'ES512' | 'PS256' | 'PS384' | 'PS512' | (string & {})
 }
 
 /** Recognized Signed JWT Header Parameters, any other Header Members may also be present. */
@@ -631,8 +631,8 @@ export interface JWTHeaderParameters extends CompactJWSHeaderParameters {
 
 /** Recognized Compact JWE Header Parameters, any other Header Members may also be present. */
 export interface CompactJWEHeaderParameters extends JWEHeaderParameters {
-  alg: string
-  enc: string
+  alg: 'RSA-OAEP' | 'RSA-OAEP-256' | 'RSA1_5' | 'A128KW' | 'A192KW' | 'A256KW' | 'dir' | 'ECDH-ES' | 'ECDH-ES+A128KW' | 'ECDH-ES+A192KW' | 'ECDH-ES+A256KW' | 'A128GCMKW' | 'A192GCMKW' | 'A256GCMKW' | 'PBES2-HS256+A128KW' | 'PBES2-HS384+A192KW' | 'PBES2-HS512+A256KW' | (string & {})
+  enc: 'A128CBC-HS256' | 'A192CBC-HS384' | 'A256CBC-HS512' | 'A128GCM' | 'A192GCM' | 'A256GCM' | (string & {})
 }
 
 /** JSON Web Key Set */

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -621,7 +621,7 @@ export interface ResolvedKey<KeyLikeType extends KeyLike = KeyLike> {
 
 /** Recognized Compact JWS Header Parameters, any other Header Members may also be present. */
 export interface CompactJWSHeaderParameters extends JWSHeaderParameters {
-  alg: 'HS256' | 'HS384' | 'HS512' | 'RS256' | 'RS384' | 'RS512'| 'ES256' | 'ES384' | 'ES512' | 'PS256' | 'PS384' | 'PS512' | (string & {})
+  alg: NonNullable<JWSHeaderParameters["alg"]>
 }
 
 /** Recognized Signed JWT Header Parameters, any other Header Members may also be present. */
@@ -631,8 +631,8 @@ export interface JWTHeaderParameters extends CompactJWSHeaderParameters {
 
 /** Recognized Compact JWE Header Parameters, any other Header Members may also be present. */
 export interface CompactJWEHeaderParameters extends JWEHeaderParameters {
-  alg: 'RSA-OAEP' | 'RSA-OAEP-256' | 'RSA1_5' | 'A128KW' | 'A192KW' | 'A256KW' | 'dir' | 'ECDH-ES' | 'ECDH-ES+A128KW' | 'ECDH-ES+A192KW' | 'ECDH-ES+A256KW' | 'A128GCMKW' | 'A192GCMKW' | 'A256GCMKW' | 'PBES2-HS256+A128KW' | 'PBES2-HS384+A192KW' | 'PBES2-HS512+A256KW' | (string & {})
-  enc: 'A128CBC-HS256' | 'A192CBC-HS384' | 'A256CBC-HS512' | 'A128GCM' | 'A192GCM' | 'A256GCM' | (string & {})
+  alg: NonNullable<JWEHeaderParameters["alg"]>
+  enc: NonNullable<JWEHeaderParameters["enc"]>
 }
 
 /** JSON Web Key Set */

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -106,7 +106,7 @@ export type KeyLike = { type: string }
 export interface JWK {
   /** JWK "alg" (Algorithm) Parameter. */
   alg?: string
-  crv?: string
+  crv?: 'P-256' | 'P-384' | 'P-521' | 'secp256k1' | 'Ed25519' | 'Ed448' | 'X25519' | 'X448'
   d?: string
   dp?: string
   dq?: string


### PR DESCRIPTION
This PR aims to provide better typescript type safety by refraining from using general types like `string`. This will improve DX by providing safeguards to input-related errors.