### PR TITLE
feat: export errors independently

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export { decodeProtectedHeader } from './util/decode_protected_header.js'
 export { decodeJwt } from './util/decode_jwt.js'
 export type { ProtectedHeaderParameters } from './util/decode_protected_header.js'
 
-export * as errors from './util/errors.js'
+export { JOSEError, JWTClaimValidationFailed, JWTExpired, JOSEAlgNotAllowed, JOSENotSupported, JWEDecryptionFailed, JWEInvalid, JWSInvalid, JWTInvalid, JWKInvalid, JWKSInvalid, JWKSNoMatchingKey, JWKSMultipleMatchingKeys, JWKSTimeout, JWSSignatureVerificationFailed }  from './util/errors.js'
 
 export { generateKeyPair } from './key/generate_key_pair.js'
 export type { GenerateKeyPairResult, GenerateKeyPairOptions } from './key/generate_key_pair.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export { decodeProtectedHeader } from './util/decode_protected_header.js'
 export { decodeJwt } from './util/decode_jwt.js'
 export type { ProtectedHeaderParameters } from './util/decode_protected_header.js'
 
-export { JOSEError, JWTClaimValidationFailed, JWTExpired, JOSEAlgNotAllowed, JOSENotSupported, JWEDecryptionFailed, JWEInvalid, JWSInvalid, JWTInvalid, JWKInvalid, JWKSInvalid, JWKSNoMatchingKey, JWKSMultipleMatchingKeys, JWKSTimeout, JWSSignatureVerificationFailed }  from './util/errors.js'
+export { JOSEError, JWTClaimValidationFailed, JWTExpired, JOSEAlgNotAllowed, JOSENotSupported, JWEDecryptionFailed, JWEInvalid, JWSInvalid, JWTInvalid, JWKInvalid, JWKSInvalid, JWKSNoMatchingKey, JWKSMultipleMatchingKeys, JWKSTimeout, JWSSignatureVerificationFailed } from './util/errors.js'
 
 export { generateKeyPair } from './key/generate_key_pair.js'
 export type { GenerateKeyPairResult, GenerateKeyPairOptions } from './key/generate_key_pair.js'


### PR DESCRIPTION
Exporting errors independently allows to not resort to nested objects for things that could be used top-level. It could also potentially aid in tree-shaking as it will be easier understood by the bundler which exports are used and which exports aren't.