### PR TITLE
chore: run CI on canary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,12 +78,15 @@ jobs:
     needs:
       - build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ["v1.x", canary]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.x
+          deno-version: ${{ matrix.version }}
       - name: Load cached dist
         uses: actions/cache@v4
         id: dist


### PR DESCRIPTION
This PR enables Deno canary in CI, which currently is the same as enabling Deno 2.0.0-rc.0. This has the obvious benefit of future-proofing this package for Deno 2, but also gives us (Deno) early insight into any issues that users may run into when migrating from Deno 1 to 2.