### PR TITLE
fix: improve error message in getKtyFromAlg

### DIFF
--- a/src/jwks/local.ts
+++ b/src/jwks/local.ts
@@ -24,7 +24,7 @@ function getKtyFromAlg(alg: unknown) {
     case 'Ed':
       return 'OKP'
     default:
-      throw new JOSENotSupported('Unsupported "alg" value for a JSON Web Key Set')
+      throw new JOSENotSupported(`"${alg}" is an unsupported signature algorithm ("alg" value) for a JSON Web Key Set`)
   }
 }
 


### PR DESCRIPTION
Just a simple change to show a more detailed error in case the signature algorithm is missing or has an invalid format.