### PR TITLE
Adding explanation for clockTolerance on JWTVerifyOptions

### DIFF
--- a/docs/jwt/verify/interfaces/JWTVerifyOptions.md
+++ b/docs/jwt/verify/interfaces/JWTVerifyOptions.md
@@ -38,6 +38,9 @@ Expected clock tolerance
 - In seconds when number (e.g. 5)
 - Parsed as seconds when a string (e.g. "5 seconds", "10 minutes", "2 hours").
 
+Used when validating the JWT "nbf" (Not Before) and "exp" (Expiration Time) claims, and when
+validating the "iat" (Issued At) claim if the maxTokenAge option is set.
+
 ***
 
 ### crit?


### PR DESCRIPTION
I was a little confused about what the `clockTolerance` option did but the docs didn't help much, so I read the code. Here's a very minor improvement based on what I found.