### PR TITLE
docs: more details for clockTolerance on JWTVerifyOptions

### DIFF
--- a/docs/jwt/decrypt/interfaces/JWTDecryptOptions.md
+++ b/docs/jwt/decrypt/interfaces/JWTDecryptOptions.md
@@ -22,10 +22,13 @@ This option makes the JWT "aud" (Audience) Claim presence required.
 
 • `optional` **clockTolerance**: `string` \| `number`
 
-Expected clock tolerance
+Clock skew tolerance
 
 - In seconds when number (e.g. 5)
 - Parsed as seconds when a string (e.g. "5 seconds", "10 minutes", "2 hours").
+
+Used when validating the JWT "nbf" (Not Before) and "exp" (Expiration Time) claims, and when
+validating the "iat" (Issued At) claim if the maxTokenAge option is set.
 
 ***
 

--- a/docs/jwt/verify/interfaces/JWTVerifyOptions.md
+++ b/docs/jwt/verify/interfaces/JWTVerifyOptions.md
@@ -38,6 +38,9 @@ Expected clock tolerance
 - In seconds when number (e.g. 5)
 - Parsed as seconds when a string (e.g. "5 seconds", "10 minutes", "2 hours").
 
+Used when validating the JWT "nbf" (Not Before) and "exp" (Expiration Time) claims, and when
+validating the "iat" (Issued At) claim if the maxTokenAge option is set.
+
 ***
 
 ### crit?

--- a/docs/jwt/verify/interfaces/JWTVerifyOptions.md
+++ b/docs/jwt/verify/interfaces/JWTVerifyOptions.md
@@ -33,7 +33,7 @@ This option makes the JWT "aud" (Audience) Claim presence required.
 
 • `optional` **clockTolerance**: `string` \| `number`
 
-Expected clock tolerance
+Clock skew tolerance
 
 - In seconds when number (e.g. 5)
 - Parsed as seconds when a string (e.g. "5 seconds", "10 minutes", "2 hours").

--- a/docs/types/interfaces/JWTClaimVerificationOptions.md
+++ b/docs/types/interfaces/JWTClaimVerificationOptions.md
@@ -22,10 +22,13 @@ This option makes the JWT "aud" (Audience) Claim presence required.
 
 • `optional` **clockTolerance**: `string` \| `number`
 
-Expected clock tolerance
+Clock skew tolerance
 
 - In seconds when number (e.g. 5)
 - Parsed as seconds when a string (e.g. "5 seconds", "10 minutes", "2 hours").
+
+Used when validating the JWT "nbf" (Not Before) and "exp" (Expiration Time) claims, and when
+validating the "iat" (Issued At) claim if the maxTokenAge option is set.
 
 ***
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -569,10 +569,13 @@ export interface JWTClaimVerificationOptions {
   audience?: string | string[]
 
   /**
-   * Expected clock tolerance
+   * Clock skew tolerance
    *
    * - In seconds when number (e.g. 5)
    * - Parsed as seconds when a string (e.g. "5 seconds", "10 minutes", "2 hours").
+   *
+   * Used when validating the JWT "nbf" (Not Before) and "exp" (Expiration Time) claims, and when
+   * validating the "iat" (Issued At) claim if the maxTokenAge option is set.
    */
   clockTolerance?: string | number
 


### PR DESCRIPTION
I was a little confused about what the clockTolerance option did but the docs didn't help much, so I read the code. Here's a very minor improvement based on what I found.