### PR TITLE
feat: re-introduce JWE "zip" (Compression Algorithm) Header Parameter support

### DIFF
--- a/docs/jwt/decrypt/interfaces/JWTDecryptOptions.md
+++ b/docs/jwt/decrypt/interfaces/JWTDecryptOptions.md
@@ -96,6 +96,20 @@ all PBES2 Key Management Algorithms, these need to be explicitly allowed using t
 
 ***
 
+### maxDecompressedLength?
+
+• `optional` **maxDecompressedLength**: `number`
+
+Maximum allowed size (in bytes) of the decompressed plaintext when the JWE `"zip"` (Compression
+Algorithm) Header Parameter is present. By default this value is set to 250000 (250 KB). The
+value must be `0`, a positive safe integer, or `Infinity`.
+
+Set to `0` to reject all compressed JWEs during decryption.
+
+Set to `Infinity` to disable the decompressed size limit.
+
+***
+
 ### maxPBES2Count?
 
 • `optional` **maxPBES2Count**: `number`

--- a/docs/types/interfaces/CompactJWEHeaderParameters.md
+++ b/docs/types/interfaces/CompactJWEHeaderParameters.md
@@ -110,17 +110,15 @@ JWE "crit" (Critical) Header Parameter
 
 ***
 
-### ~~zip?~~
+### zip?
 
 • `optional` **zip**: `string`
 
-JWE "zip" (Compression Algorithm) Header Parameter. This parameter is not supported anymore.
+JWE "zip" (Compression Algorithm) Header Parameter.
 
-#### Deprecated
-
-Compression of data SHOULD NOT be done before encryption, because such compressed
-  data often reveals information about the plaintext.
+The only supported value is `"DEF"` (DEFLATE). Requires the `CompressionStream` /
+`DecompressionStream` APIs to be available in the runtime.
 
 #### See
 
-[Avoid Compression of Encryption Inputs](https://www.rfc-editor.org/rfc/rfc8725#name-avoid-compression-of-encryp)
+[JWE "zip" Header Parameter](https://www.rfc-editor.org/rfc/rfc7516#section-4.1.3)

--- a/docs/types/interfaces/DecryptOptions.md
+++ b/docs/types/interfaces/DecryptOptions.md
@@ -54,6 +54,20 @@ all PBES2 Key Management Algorithms, these need to be explicitly allowed using t
 
 ***
 
+### maxDecompressedLength?
+
+• `optional` **maxDecompressedLength**: `number`
+
+Maximum allowed size (in bytes) of the decompressed plaintext when the JWE `"zip"` (Compression
+Algorithm) Header Parameter is present. By default this value is set to 250000 (250 KB). The
+value must be `0`, a positive safe integer, or `Infinity`.
+
+Set to `0` to reject all compressed JWEs during decryption.
+
+Set to `Infinity` to disable the decompressed size limit.
+
+***
+
 ### maxPBES2Count?
 
 • `optional` **maxPBES2Count**: `number`

--- a/docs/types/interfaces/JWEHeaderParameters.md
+++ b/docs/types/interfaces/JWEHeaderParameters.md
@@ -110,17 +110,15 @@ JWE "enc" (Encryption Algorithm) Header Parameter
 
 ***
 
-### ~~zip?~~
+### zip?
 
 • `optional` **zip**: `string`
 
-JWE "zip" (Compression Algorithm) Header Parameter. This parameter is not supported anymore.
+JWE "zip" (Compression Algorithm) Header Parameter.
 
-#### Deprecated
-
-Compression of data SHOULD NOT be done before encryption, because such compressed
-  data often reveals information about the plaintext.
+The only supported value is `"DEF"` (DEFLATE). Requires the `CompressionStream` /
+`DecompressionStream` APIs to be available in the runtime.
 
 #### See
 
-[Avoid Compression of Encryption Inputs](https://www.rfc-editor.org/rfc/rfc8725#name-avoid-compression-of-encryp)
+[JWE "zip" Header Parameter](https://www.rfc-editor.org/rfc/rfc7516#section-4.1.3)

--- a/src/jwe/flattened/decrypt.ts
+++ b/src/jwe/flattened/decrypt.ts
@@ -17,6 +17,7 @@ import { validateCrit } from '../../lib/validate_crit.js'
 import { validateAlgorithms } from '../../lib/validate_algorithms.js'
 import { normalizeKey } from '../../lib/normalize_key.js'
 import { checkKeyType } from '../../lib/check_key_type.js'
+import { decompress } from '../../lib/deflate.js'
 
 /**
  * Interface for Flattened JWE Decryption dynamic key resolution. No token components have been
@@ -144,9 +145,15 @@ export async function flattenedDecrypt(
 
   validateCrit(JWEInvalid, new Map(), options?.crit, parsedProt, joseHeader)
 
-  if (joseHeader.zip !== undefined) {
+  if (joseHeader.zip !== undefined && joseHeader.zip !== 'DEF') {
     throw new JOSENotSupported(
-      'JWE "zip" (Compression Algorithm) Header Parameter is not supported.',
+      'Unsupported JWE "zip" (Compression Algorithm) Header Parameter value.',
+    )
+  }
+
+  if (joseHeader.zip !== undefined && !parsedProt?.zip) {
+    throw new JWEInvalid(
+      'JWE "zip" (Compression Algorithm) Header Parameter MUST be in a protected header.',
     )
   }
 
@@ -247,6 +254,22 @@ export async function flattenedDecrypt(
   const plaintext = await decrypt(enc, cek, ciphertext, iv, tag, additionalData)
 
   const result: types.FlattenedDecryptResult = { plaintext }
+
+  if (joseHeader.zip === 'DEF') {
+    const maxDecompressedLength = options?.maxDecompressedLength ?? 250_000
+    if (maxDecompressedLength === 0) {
+      throw new JOSENotSupported(
+        'JWE "zip" (Compression Algorithm) Header Parameter is not supported.',
+      )
+    }
+    if (
+      maxDecompressedLength !== Infinity &&
+      (!Number.isSafeInteger(maxDecompressedLength) || maxDecompressedLength < 1)
+    ) {
+      throw new TypeError('maxDecompressedLength must be 0, a positive safe integer, or Infinity')
+    }
+    result.plaintext = await decompress(plaintext, maxDecompressedLength)
+  }
 
   if (jwe.protected !== undefined) {
     result.protectedHeader = parsedProt

--- a/src/jwe/flattened/encrypt.ts
+++ b/src/jwe/flattened/encrypt.ts
@@ -15,6 +15,7 @@ import { concat, encode } from '../../lib/buffer_utils.js'
 import { validateCrit } from '../../lib/validate_crit.js'
 import { normalizeKey } from '../../lib/normalize_key.js'
 import { checkKeyType } from '../../lib/check_key_type.js'
+import { compress } from '../../lib/deflate.js'
 
 /**
  * The FlattenedEncrypt class is used to build and encrypt Flattened JWE objects.
@@ -196,9 +197,15 @@ export class FlattenedEncrypt {
 
     validateCrit(JWEInvalid, new Map(), options?.crit, this.#protectedHeader, joseHeader)
 
-    if (joseHeader.zip !== undefined) {
+    if (joseHeader.zip !== undefined && joseHeader.zip !== 'DEF') {
       throw new JOSENotSupported(
-        'JWE "zip" (Compression Algorithm) Header Parameter is not supported.',
+        'Unsupported JWE "zip" (Compression Algorithm) Header Parameter value.',
+      )
+    }
+
+    if (joseHeader.zip !== undefined && !this.#protectedHeader?.zip) {
+      throw new JWEInvalid(
+        'JWE "zip" (Compression Algorithm) Header Parameter MUST be in a protected header.',
       )
     }
 
@@ -269,13 +276,12 @@ export class FlattenedEncrypt {
       additionalData = protectedHeaderB
     }
 
-    const { ciphertext, tag, iv } = await encrypt(
-      enc,
-      this.#plaintext,
-      cek,
-      this.#iv,
-      additionalData,
-    )
+    let plaintext = this.#plaintext
+    if (joseHeader.zip === 'DEF') {
+      plaintext = await compress(plaintext)
+    }
+
+    const { ciphertext, tag, iv } = await encrypt(enc, plaintext, cek, this.#iv, additionalData)
 
     const jwe: types.FlattenedJWE = {
       ciphertext: b64u(ciphertext),

--- a/src/jwe/general/encrypt.ts
+++ b/src/jwe/general/encrypt.ts
@@ -258,9 +258,15 @@ export class GeneralEncrypt {
 
       validateCrit(JWEInvalid, new Map(), recipient.options.crit, this.#protectedHeader, joseHeader)
 
-      if (joseHeader.zip !== undefined) {
+      if (joseHeader.zip !== undefined && joseHeader.zip !== 'DEF') {
         throw new JOSENotSupported(
-          'JWE "zip" (Compression Algorithm) Header Parameter is not supported.',
+          'Unsupported JWE "zip" (Compression Algorithm) Header Parameter value.',
+        )
+      }
+
+      if (joseHeader.zip !== undefined && !this.#protectedHeader?.zip) {
+        throw new JWEInvalid(
+          'JWE "zip" (Compression Algorithm) Header Parameter MUST be in a protected header.',
         )
       }
     }

--- a/src/lib/deflate.ts
+++ b/src/lib/deflate.ts
@@ -1,0 +1,53 @@
+import { JOSENotSupported, JWEInvalid } from '../util/errors.js'
+import { concat } from './buffer_utils.js'
+
+function supported(name: 'CompressionStream' | 'DecompressionStream') {
+  if (typeof globalThis[name] === 'undefined') {
+    throw new JOSENotSupported(
+      `JWE "zip" (Compression Algorithm) Header Parameter requires the ${name} API.`,
+    )
+  }
+}
+
+export async function compress(input: Uint8Array): Promise<Uint8Array> {
+  supported('CompressionStream')
+
+  const cs = new CompressionStream('deflate-raw')
+  const writer = cs.writable.getWriter()
+  writer.write(input as Uint8Array<ArrayBuffer>)
+  writer.close()
+
+  const chunks: Uint8Array[] = []
+  const reader = cs.readable.getReader()
+  for (;;) {
+    const { value, done } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+
+  return concat(...chunks)
+}
+
+export async function decompress(input: Uint8Array, maxLength: number): Promise<Uint8Array> {
+  supported('DecompressionStream')
+
+  const ds = new DecompressionStream('deflate-raw')
+  const writer = ds.writable.getWriter()
+  writer.write(input as Uint8Array<ArrayBuffer>)
+  writer.close()
+
+  const chunks: Uint8Array[] = []
+  let length = 0
+  const reader = ds.readable.getReader()
+  for (;;) {
+    const { value, done } = await reader.read()
+    if (done) break
+    chunks.push(value)
+    length += value.byteLength
+    if (maxLength !== Infinity && length > maxLength) {
+      throw new JWEInvalid('Decompressed plaintext exceeded the configured limit')
+    }
+  }
+
+  return concat(...chunks)
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -415,12 +415,12 @@ export interface JWEHeaderParameters extends JoseHeaderParameters {
   crit?: string[]
 
   /**
-   * JWE "zip" (Compression Algorithm) Header Parameter. This parameter is not supported anymore.
+   * JWE "zip" (Compression Algorithm) Header Parameter.
    *
-   * @deprecated Compression of data SHOULD NOT be done before encryption, because such compressed
-   *   data often reveals information about the plaintext.
+   * The only supported value is `"DEF"` (DEFLATE). Requires the `CompressionStream` /
+   * `DecompressionStream` APIs to be available in the runtime.
    *
-   * @see {@link https://www.rfc-editor.org/rfc/rfc8725#name-avoid-compression-of-encryp Avoid Compression of Encryption Inputs}
+   * @see {@link https://www.rfc-editor.org/rfc/rfc7516#section-4.1.3 JWE "zip" Header Parameter}
    */
   zip?: string
 
@@ -474,6 +474,17 @@ export interface DecryptOptions extends CritOption {
    * this value is set to 10000.
    */
   maxPBES2Count?: number
+
+  /**
+   * Maximum allowed size (in bytes) of the decompressed plaintext when the JWE `"zip"` (Compression
+   * Algorithm) Header Parameter is present. By default this value is set to 250000 (250 KB). The
+   * value must be `0`, a positive safe integer, or `Infinity`.
+   *
+   * Set to `0` to reject all compressed JWEs during decryption.
+   *
+   * Set to `Infinity` to disable the decompressed size limit.
+   */
+  maxDecompressedLength?: number
 }
 
 /** JWE Encryption options. */

--- a/tap/cookbook.ts
+++ b/tap/cookbook.ts
@@ -132,7 +132,7 @@ export default (
     }
 
     function supported(vector: any) {
-      if (vector.input.zip) {
+      if (vector.input.zip && typeof globalThis.CompressionStream === 'undefined') {
         return false
       }
       return env.supported(vector.input.alg) && env.supported(vector.input.enc)

--- a/test/jwe/zip.test.ts
+++ b/test/jwe/zip.test.ts
@@ -1,0 +1,256 @@
+import test from 'ava'
+
+import {
+  FlattenedEncrypt,
+  flattenedDecrypt,
+  CompactEncrypt,
+  compactDecrypt,
+  GeneralEncrypt,
+  generalDecrypt,
+  EncryptJWT,
+  jwtDecrypt,
+  generateSecret,
+} from '../../src/index.js'
+
+const hasCompressionStreams = typeof globalThis.CompressionStream !== 'undefined'
+
+const encode = TextEncoder.prototype.encode.bind(new TextEncoder())
+
+test.before(async (t) => {
+  t.context.plaintext = encode("It's a dangerous business, Frodo, going out your door.")
+  t.context.secret = await generateSecret('A128GCM')
+})
+
+if (hasCompressionStreams) {
+  test('FlattenedEncrypt/flattenedDecrypt with zip: DEF', async (t) => {
+    const jwe = await new FlattenedEncrypt(t.context.plaintext)
+      .setProtectedHeader({ alg: 'dir', enc: 'A128GCM', zip: 'DEF' })
+      .encrypt(t.context.secret)
+
+    const { plaintext } = await flattenedDecrypt(jwe, t.context.secret)
+    t.deepEqual(plaintext, t.context.plaintext)
+  })
+
+  test('CompactEncrypt/compactDecrypt with zip: DEF', async (t) => {
+    const jwe = await new CompactEncrypt(t.context.plaintext)
+      .setProtectedHeader({ alg: 'dir', enc: 'A128GCM', zip: 'DEF' })
+      .encrypt(t.context.secret)
+
+    const { plaintext } = await compactDecrypt(jwe, t.context.secret)
+    t.deepEqual(plaintext, t.context.plaintext)
+  })
+
+  test('GeneralEncrypt/generalDecrypt with zip: DEF', async (t) => {
+    const jwe = await new GeneralEncrypt(t.context.plaintext)
+      .setProtectedHeader({ enc: 'A128GCM', zip: 'DEF' })
+      .addRecipient(t.context.secret)
+      .setUnprotectedHeader({ alg: 'A128GCMKW' })
+      .encrypt()
+
+    const { plaintext } = await generalDecrypt(jwe, t.context.secret)
+    t.deepEqual(plaintext, t.context.plaintext)
+  })
+
+  test('EncryptJWT/jwtDecrypt with zip: DEF', async (t) => {
+    const jwt = await new EncryptJWT({ foo: 'bar' })
+      .setProtectedHeader({ alg: 'dir', enc: 'A128GCM', zip: 'DEF' })
+      .encrypt(t.context.secret)
+
+    const { payload, protectedHeader } = await jwtDecrypt(jwt, t.context.secret)
+    t.is(payload.foo, 'bar')
+    t.is(protectedHeader.zip, 'DEF')
+  })
+
+  test('jwtDecrypt with zip: DEF and maxDecompressedLength option', async (t) => {
+    const jwt = await new EncryptJWT({ foo: 'bar' })
+      .setProtectedHeader({ alg: 'dir', enc: 'A128GCM', zip: 'DEF' })
+      .encrypt(t.context.secret)
+
+    // Should succeed with a generous limit
+    await t.notThrowsAsync(jwtDecrypt(jwt, t.context.secret, { maxDecompressedLength: Infinity }))
+
+    // Should succeed with a reasonable limit
+    await t.notThrowsAsync(jwtDecrypt(jwt, t.context.secret, { maxDecompressedLength: 1024 }))
+  })
+
+  test('maxDecompressedLength: 0 disables zip support on decrypt', async (t) => {
+    const jwe = await new CompactEncrypt(t.context.plaintext)
+      .setProtectedHeader({ alg: 'dir', enc: 'A128GCM', zip: 'DEF' })
+      .encrypt(t.context.secret)
+
+    await t.throwsAsync(compactDecrypt(jwe, t.context.secret, { maxDecompressedLength: 0 }), {
+      message: 'JWE "zip" (Compression Algorithm) Header Parameter is not supported.',
+      code: 'ERR_JOSE_NOT_SUPPORTED',
+    })
+  })
+
+  test('maxDecompressedLength: Infinity disables bomb protection', async (t) => {
+    // Create a large plaintext
+    const largePlaintext = new Uint8Array(300_000)
+    const jwe = await new CompactEncrypt(largePlaintext)
+      .setProtectedHeader({ alg: 'dir', enc: 'A128GCM', zip: 'DEF' })
+      .encrypt(t.context.secret)
+
+    // Default limit (250KB) should reject
+    await t.throwsAsync(compactDecrypt(jwe, t.context.secret), {
+      message: 'Decompressed plaintext exceeded the configured limit',
+      code: 'ERR_JWE_INVALID',
+    })
+
+    // Infinity should allow
+    const { plaintext } = await compactDecrypt(jwe, t.context.secret, {
+      maxDecompressedLength: Infinity,
+    })
+    t.is(plaintext.byteLength, 300_000)
+  })
+
+  test('maxDecompressedLength enforcement', async (t) => {
+    const plaintext = new Uint8Array(1024)
+    const jwe = await new CompactEncrypt(plaintext)
+      .setProtectedHeader({ alg: 'dir', enc: 'A128GCM', zip: 'DEF' })
+      .encrypt(t.context.secret)
+
+    await t.throwsAsync(compactDecrypt(jwe, t.context.secret, { maxDecompressedLength: 512 }), {
+      message: 'Decompressed plaintext exceeded the configured limit',
+      code: 'ERR_JWE_INVALID',
+    })
+
+    await t.notThrowsAsync(compactDecrypt(jwe, t.context.secret, { maxDecompressedLength: 2048 }))
+  })
+
+  test('maxDecompressedLength must be 0, a positive safe integer, or Infinity', async (t) => {
+    const jwe = await new CompactEncrypt(t.context.plaintext)
+      .setProtectedHeader({ alg: 'dir', enc: 'A128GCM', zip: 'DEF' })
+      .encrypt(t.context.secret)
+
+    for (const value of [-1, 0.5, NaN, -Infinity]) {
+      await t.throwsAsync(compactDecrypt(jwe, t.context.secret, { maxDecompressedLength: value }), {
+        instanceOf: TypeError,
+        message: 'maxDecompressedLength must be 0, a positive safe integer, or Infinity',
+      })
+    }
+  })
+}
+
+test('unsupported zip value on encrypt throws JOSENotSupported', async (t) => {
+  await t.throwsAsync(
+    new FlattenedEncrypt(t.context.plaintext)
+      .setProtectedHeader({ alg: 'dir', enc: 'A128GCM', zip: 'gzip' })
+      .encrypt(t.context.secret),
+    {
+      message: 'Unsupported JWE "zip" (Compression Algorithm) Header Parameter value.',
+      code: 'ERR_JOSE_NOT_SUPPORTED',
+    },
+  )
+})
+
+test('zip must be in a protected header on encrypt', async (t) => {
+  await t.throwsAsync(
+    new FlattenedEncrypt(t.context.plaintext)
+      .setProtectedHeader({ alg: 'dir', enc: 'A128GCM' })
+      .setSharedUnprotectedHeader({ zip: 'DEF' })
+      .encrypt(t.context.secret),
+    {
+      message: 'JWE "zip" (Compression Algorithm) Header Parameter MUST be in a protected header.',
+      code: 'ERR_JWE_INVALID',
+    },
+  )
+
+  await t.throwsAsync(
+    new FlattenedEncrypt(t.context.plaintext)
+      .setProtectedHeader({ alg: 'dir', enc: 'A128GCM' })
+      .setUnprotectedHeader({ zip: 'DEF' })
+      .encrypt(t.context.secret),
+    {
+      message: 'JWE "zip" (Compression Algorithm) Header Parameter MUST be in a protected header.',
+      code: 'ERR_JWE_INVALID',
+    },
+  )
+})
+
+test('zip must be in a protected header on encrypt (multi-recipient)', async (t) => {
+  const secret1 = await generateSecret('A128KW')
+  const secret2 = await generateSecret('A128KW')
+
+  await t.throwsAsync(
+    new GeneralEncrypt(t.context.plaintext)
+      .setProtectedHeader({ enc: 'A128GCM' })
+      .setSharedUnprotectedHeader({ zip: 'DEF' })
+      .addRecipient(secret1)
+      .setUnprotectedHeader({ alg: 'A128KW' })
+      .addRecipient(secret2)
+      .setUnprotectedHeader({ alg: 'A128KW' })
+      .encrypt(),
+    {
+      message: 'JWE "zip" (Compression Algorithm) Header Parameter MUST be in a protected header.',
+      code: 'ERR_JWE_INVALID',
+    },
+  )
+
+  await t.throwsAsync(
+    new GeneralEncrypt(t.context.plaintext)
+      .setProtectedHeader({ enc: 'A128GCM' })
+      .addRecipient(secret1)
+      .setUnprotectedHeader({ alg: 'A128KW' })
+      .addRecipient(secret2)
+      .setUnprotectedHeader({ alg: 'A128KW', zip: 'DEF' })
+      .encrypt(),
+    {
+      message: 'JWE "zip" (Compression Algorithm) Header Parameter MUST be in a protected header.',
+      code: 'ERR_JWE_INVALID',
+    },
+  )
+})
+
+test('zip must be in a protected header on decrypt', async (t) => {
+  const jwe = await new FlattenedEncrypt(t.context.plaintext)
+    .setProtectedHeader({ alg: 'dir', enc: 'A128GCM' })
+    .encrypt(t.context.secret)
+
+  // Tamper: put zip in unprotected header
+  const tampered = { ...jwe, unprotected: { zip: 'DEF' } }
+  await t.throwsAsync(flattenedDecrypt(tampered, t.context.secret), {
+    message: 'JWE "zip" (Compression Algorithm) Header Parameter MUST be in a protected header.',
+    code: 'ERR_JWE_INVALID',
+  })
+
+  // Tamper: put zip in per-recipient header
+  const tampered2 = { ...jwe, header: { zip: 'DEF' } }
+  await t.throwsAsync(flattenedDecrypt(tampered2, t.context.secret), {
+    message: 'JWE "zip" (Compression Algorithm) Header Parameter MUST be in a protected header.',
+    code: 'ERR_JWE_INVALID',
+  })
+})
+
+test('unsupported zip value on decrypt throws JOSENotSupported', async (t) => {
+  // Build a JWE without zip, then tamper the protected header to have zip: gzip
+  const jwe = await new FlattenedEncrypt(t.context.plaintext)
+    .setProtectedHeader({ alg: 'dir', enc: 'A128GCM' })
+    .encrypt(t.context.secret)
+
+  // Replace protected header with one containing zip: gzip
+  const tampered = {
+    ...jwe,
+    protected: btoa(JSON.stringify({ alg: 'dir', enc: 'A128GCM', zip: 'gzip' }))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, ''),
+  }
+
+  await t.throwsAsync(flattenedDecrypt(tampered, t.context.secret), {
+    code: 'ERR_JOSE_NOT_SUPPORTED',
+  })
+})
+
+if (!hasCompressionStreams) {
+  test('zip: DEF throws JOSENotSupported when CompressionStream is unavailable', async (t) => {
+    await t.throwsAsync(
+      new FlattenedEncrypt(t.context.plaintext)
+        .setProtectedHeader({ alg: 'dir', enc: 'A128GCM', zip: 'DEF' })
+        .encrypt(t.context.secret),
+      {
+        code: 'ERR_JOSE_NOT_SUPPORTED',
+      },
+    )
+  })
+}


### PR DESCRIPTION
Uses the CompressionStream/DecompressionStream APIs with "deflate-raw" to support the "DEF" compression algorithm value.

Decompressed output is limited to 250 KB by default, configurable via the maxDecompressedLength decrypt option.

Runtimes lacking CompressionStream/DecompressionStream (e.g. Node.js 20) will continue to throw JOSENotSupported when zip is encountered.