### PR TITLE
Add TypeScript types for key generation functions

### DIFF
--- a/src/key/generate_key_pair.ts
+++ b/src/key/generate_key_pair.ts
@@ -47,6 +47,26 @@ export interface GenerateKeyPairOptions {
   extractable?: boolean
 }
 
+/**
+ * JWA Algorithm Identifier for asymmetric key pair generation.
+ *
+ * The {@link https://github.com/panva/jose/issues/114 Algorithm Selection Guide} should be consulted
+ * as a quick reference if you're having trouble selecting an appropriate algorithm for your needs.
+ *
+ * See {@link https://github.com/panva/jose/issues/210 Algorithm Key Requirements} for usage support
+ * details.
+ */
+export type KeyPairAlgorithm =
+  | `PS${'256' | '384' | '512'}`
+  | `RS${'256' | '384' | '512'}`
+  | `RSA-OAEP`
+  | `RSA-OAEP-${'256' | '384' | '512'}`
+  | `ES${'256' | '384' | '512'}`
+  | `Ed${'25519' | 'DSA'}`
+  | `ML-DSA-${'44' | '65' | '87'}`
+  | `ECDH-ES`
+  | `ECDH-ES+A${'128' | '192' | '256'}KW`
+
 function getModulusLengthOption(options?: GenerateKeyPairOptions) {
   const modulusLength = options?.modulusLength ?? 2048
   if (typeof modulusLength !== 'number' || modulusLength < 2048) {
@@ -81,7 +101,7 @@ function getModulusLengthOption(options?: GenerateKeyPairOptions) {
  * @param options Additional options passed down to the key pair generation.
  */
 export async function generateKeyPair(
-  alg: string,
+  alg: KeyPairAlgorithm,
   options?: GenerateKeyPairOptions,
 ): Promise<GenerateKeyPairResult> {
   let algorithm: RsaHashedKeyGenParams | EcKeyGenParams | KeyAlgorithm

--- a/src/key/generate_key_pair.ts
+++ b/src/key/generate_key_pair.ts
@@ -23,7 +23,7 @@ export interface GenerateKeyPairOptions {
    * The EC "crv" (Curve) or OKP "crv" (Subtype of Key Pair) value to generate. The curve must be
    * both supported on the runtime as well as applicable for the given JWA algorithm identifier.
    */
-  crv?: string
+  crv?: `P-${'256' | '384' | '521'}` | 'X25519'
 
   /**
    * A hint for RSA algorithms to generate an RSA key of a given `modulusLength` (Key size in bits).

--- a/src/key/generate_secret.ts
+++ b/src/key/generate_secret.ts
@@ -21,6 +21,22 @@ export interface GenerateSecretOptions {
 }
 
 /**
+ * JWA Algorithm Identifier for symmetric secret generation.
+ *
+ * The {@link https://github.com/panva/jose/issues/114 Algorithm Selection Guide} should be consulted
+ * as a quick reference if you're having trouble selecting an appropriate algorithm for your needs.
+ *
+ * See {@link https://github.com/panva/jose/issues/210 Algorithm Key Requirements} for usage support
+ * details.
+ */
+export type SecretKeyAlgorithm =
+  | `HS${'256' | '384' | '512'}`
+  | `A${'128' | '192' | '256'}${'GCM' | 'KW' | 'GCMKW'}`
+  | `A128CBC-HS256`
+  | `A192CBC-HS384`
+  | `A256CBC-HS512`
+
+/**
  * Generates a symmetric secret key for a given JWA algorithm identifier.
  *
  * > [!NOTE]\
@@ -45,7 +61,7 @@ export interface GenerateSecretOptions {
  * @param options Additional options passed down to the secret generation.
  */
 export async function generateSecret(
-  alg: string,
+  alg: SecretKeyAlgorithm,
   options?: GenerateSecretOptions,
 ): Promise<types.CryptoKey | Uint8Array> {
   let length: number


### PR DESCRIPTION
Sorry for not creating a discussion first -- alas, I read the CONTRIBUTING.md just after finishing up the code for this contribution.

## Benefits

- It's simply more convenient (for us puny humans, at least) to have autocomplete for the accepted algorithms.
- Protects against potential typos, which may cause runtime crashes, by providing a type error.
- I expect that this change is **NOT** breaking, because using an invalid algorithm causes a runtime crash anyway.

## Costs

The weakest link in any cybersecurity system is humans; there is a danger that, by introducing automatic type hints, users may potentially do less pre-reading before using Jose and accidentally introduce security vulnerabilities into their own code-bases by using inappropriate algorithms. I have tried to link to the relevant documentation in the JSDoc comments of these types to reduce the incidence rate of this.

## Tests(?)

I made sure to run `npm format` and `npm test` before contributing this. Nothing seems broken from what I can glean.

## AI Disclosure

All the code was written by hand. I submitted it to Claude to review, where it *did* catch a typo that I'd made in the identifier for the type `SecretKeyAlgorithm`.