### PR TITLE
fix: reject + and / in the no-native-fromBase64 decode fallback

### DIFF
--- a/src/util/base64url.ts
+++ b/src/util/base64url.ts
@@ -21,6 +21,11 @@ export function decode(input: Uint8Array | string): Uint8Array {
   if (encoded instanceof Uint8Array) {
     encoded = decoder.decode(encoded)
   }
+  if (encoded.indexOf('+') !== -1 || encoded.indexOf('/') !== -1) {
+    // + and / are not in the Base64URL alphabet; reject them here so this
+    // path matches Uint8Array.fromBase64(..., { alphabet: 'base64url' }) above
+    throw new TypeError('The input to be decoded is not correctly encoded.')
+  }
   encoded = encoded.replace(/-/g, '+').replace(/_/g, '/')
   try {
     return decodeBase64(encoded)

--- a/test/unit/base64url.test.ts
+++ b/test/unit/base64url.test.ts
@@ -1,0 +1,29 @@
+import test from 'ava'
+
+import { decode } from '../../src/util/base64url.js'
+
+// `+` and `/` are valid Base64 but not Base64URL. Uint8Array.fromBase64 with
+// the base64url alphabet rejects them, so the no-native-fromBase64 fallback
+// (which translates `-_` to `+/` and decodes via atob) must reject them too
+// instead of accepting them as standard Base64.
+
+test('decode rejects + and / (native path)', (t) => {
+  t.throws(() => decode('+/+/'))
+  t.throws(() => decode('AB+CD'))
+  t.deepEqual(decode('-_-_'), new Uint8Array([0xfb, 0xff, 0xbf]))
+})
+
+test.serial('decode rejects + and / (fallback path)', (t) => {
+  // @ts-ignore
+  const native = Uint8Array.fromBase64
+  try {
+    // @ts-ignore
+    delete Uint8Array.fromBase64
+    t.throws(() => decode('+/+/'), { instanceOf: TypeError })
+    t.throws(() => decode('AB/CD'), { instanceOf: TypeError })
+    t.deepEqual(decode('-_-_'), new Uint8Array([0xfb, 0xff, 0xbf]))
+  } finally {
+    // @ts-ignore
+    Uint8Array.fromBase64 = native
+  }
+})


### PR DESCRIPTION
### Problem

`base64url.decode()` decodes the same input differently across runtimes when it contains `+` or `/`.

The native path rejects them, since they are not in the Base64URL alphabet:

```js
Uint8Array.fromBase64(input, { alphabet: 'base64url' }) // throws on + or /
```

The fallback (runtimes without `Uint8Array.fromBase64`) translates `-_` → `+/` and decodes via `atob`, which accepts standard-Base64 `+` and `/`:

```js
encoded = encoded.replace(/-/g, '+').replace(/_/g, '/')
return decodeBase64(encoded) // atob accepts + and /
```

So the same JWS/JWE/JWT segment is accepted on a runtime without the native method and rejected on one with it:

```js
delete Uint8Array.fromBase64
decode('+/+/') // fallback: Uint8Array(3) [251, 255, 191];  native: throws
```

This is a portability inconsistency rather than a security issue (a forged signature still fails verification), but a given segment should decode the same way on every runtime, and the fallback should match the alphabet the native path already enforces.

### Fix

Reject `+` and `/` in the fallback before the `-_` → `+/` translation, so it behaves like the native path. Only those two characters change; the padding and whitespace that `atob` tolerates are untouched.

### Tests

Added a unit test exercising both paths (native, and the fallback forced by removing `Uint8Array.fromBase64`): `+`/`/` are rejected and valid base64url still decodes. The fallback case fails on `main` and passes with the fix.