### PR TITLE
Avoid 32-bit truncation of the AES-CBC-HMAC AAD bit length

### DIFF
--- a/src/lib/content_encryption.ts
+++ b/src/lib/content_encryption.ts
@@ -132,7 +132,7 @@ async function cbcEncrypt(
     ),
   )
 
-  const macData = concat(aad, iv, ciphertext, uint64be(aad.length << 3))
+  const macData = concat(aad, iv, ciphertext, uint64be(aad.length * 8))
   const tag = await cbcHmacTag(macKey, macData, keySize)
 
   return { ciphertext, tag, iv }
@@ -175,7 +175,7 @@ async function cbcDecrypt(
 ) {
   const { encKey, macKey, keySize } = await cbcKeySetup(enc, cek, 'decrypt')
 
-  const macData = concat(aad, iv, ciphertext, uint64be(aad.length << 3))
+  const macData = concat(aad, iv, ciphertext, uint64be(aad.length * 8))
   const expectedTag = await cbcHmacTag(macKey, macData, keySize)
 
   let macCheckPassed!: boolean


### PR DESCRIPTION
Just a really small correctness thing. In the AES-CBC-HMAC code, the aad bit length is using `<< 3`. But that gives a wrong answer for larger numbers (around 256mib), since it's a 32-bit op, going into a 64-bit uint64be.

Different repo, similar issue to: https://github.com/dvsekhvalnov/jose-jwt/issues/69
