### PR TITLE
fix(types): accept host CryptoKey declarations

### DIFF
--- a/docs/types/interfaces/CryptoKeyStructuralFallback.md
+++ b/docs/types/interfaces/CryptoKeyStructuralFallback.md
@@ -6,10 +6,10 @@ Support from the community to continue maintaining and improving this module is 
 
 **`Internal`**
 
-Used as [CryptoKey](../type-aliases/CryptoKey.md) only when the host runtime's `crypto` global is not typed at all, e.g. a
-consumer compiling with neither the DOM lib nor `@types/node`. Whenever a `CryptoKey` type is
-available it is aliased instead, deliberately, so that this module never introduces a competing
-nominal `CryptoKey` and values flow freely to and from [SubtleCrypto](https://developer.mozilla.org/docs/Web/API/SubtleCrypto) APIs.
+Used as [CryptoKey](../type-aliases/CryptoKey.md) when the host runtime's `crypto` global is not exposed on `typeof
+globalThis`, including when it is absent from ambient types or declared with `const` or `let`. It
+remains structurally compatible with host [CryptoKey](https://developer.mozilla.org/docs/Web/API/CryptoKey) declarations so values flow freely to
+and from [SubtleCrypto](https://developer.mozilla.org/docs/Web/API/SubtleCrypto) APIs.
 
 ## Properties
 
@@ -31,10 +31,10 @@ nominal `CryptoKey` and values flow freely to and from [SubtleCrypto](https://de
 
 ### type
 
-• `readonly` **type**: `"private"` \| `"public"` \| `"secret"`
+• `readonly` **type**: `string`
 
 ***
 
 ### usages
 
-• `readonly` **usages**: (`"decrypt"` \| `"deriveBits"` \| `"deriveKey"` \| `"encrypt"` \| `"sign"` \| `"unwrapKey"` \| `"verify"` \| `"wrapKey"`)[]
+• `readonly` **usages**: `string`[]

--- a/docs/types/interfaces/KeyObject.md
+++ b/docs/types/interfaces/KeyObject.md
@@ -12,4 +12,4 @@ use the Node.js runtime APIs [createPublicKey](https://nodejs.org/api/crypto.htm
 
 ### type
 
-• **type**: `"private"` \| `"public"` \| `"secret"`
+• **type**: `string`

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -900,7 +900,7 @@ export interface JSONWebKeySet {
  * {@link !createSecretKey} to obtain a {@link !KeyObject} from your existing key material.
  */
 export interface KeyObject {
-  type: 'private' | 'public' | 'secret'
+  type: string
 }
 
 /**
@@ -916,20 +916,18 @@ export type CryptoKey = typeof globalThis extends {
   : CryptoKeyStructuralFallback
 
 /**
- * Used as {@link CryptoKey} only when the host runtime's `crypto` global is not typed at all, e.g. a
- * consumer compiling with neither the DOM lib nor `@types/node`. Whenever a `CryptoKey` type is
- * available it is aliased instead, deliberately, so that this module never introduces a competing
- * nominal `CryptoKey` and values flow freely to and from {@link !SubtleCrypto} APIs.
+ * Used as {@link CryptoKey} when the host runtime's `crypto` global is not exposed on `typeof
+ * globalThis`, including when it is absent from ambient types or declared with `const` or `let`. It
+ * remains structurally compatible with host {@link !CryptoKey} declarations so values flow freely to
+ * and from {@link !SubtleCrypto} APIs.
  *
  * @internal
  */
 export interface CryptoKeyStructuralFallback {
   readonly algorithm: { name: string }
   readonly extractable: boolean
-  readonly type: 'private' | 'public' | 'secret'
-  readonly usages: (
-    'decrypt' | 'deriveBits' | 'deriveKey' | 'encrypt' | 'sign' | 'unwrapKey' | 'verify' | 'wrapKey'
-  )[]
+  readonly type: string
+  readonly usages: string[]
 }
 
 /** Generic interface for JWT producing classes. */

--- a/test-d/api.ts
+++ b/test-d/api.ts
@@ -482,10 +482,8 @@ async function payloadGenerics() {
     .sign(secret)
 }
 
-/* KeyObject stands in for Node's opaque crypto.KeyObject and must not admit arbitrary objects. */
+/* KeyObject must remain structurally compatible with runtime declarations that use `string`. */
 {
-  // @ts-expect-error Blob, Event and friends are not keys
-  const _bad: jose.KeyObject = { type: 'totally-bogus' }
-  const _good: jose.KeyObject = { type: 'secret' }
-  const _types: Equals<jose.KeyObject['type'], 'private' | 'public' | 'secret'> = true
+  const _good: jose.KeyObject = { type: anyString }
+  const _type: Equals<jose.KeyObject['type'], string> = true
 }

--- a/test-d/fallback.ts
+++ b/test-d/fallback.ts
@@ -1,22 +1,50 @@
 // Selects the CryptoKey structural fallback by compiling without DOM or Node ambient types.
-import type * as jose from 'jose'
+import * as jose from 'jose'
 
 declare global {
   interface AbortSignal {}
   interface Headers {}
   interface Response {}
   interface URL {}
+
+  abstract class CryptoKey {
+    readonly type: string
+    readonly extractable: boolean
+    readonly algorithm: { name: string }
+    readonly usages: string[]
+  }
+
+  interface CryptoKeyPair {
+    privateKey: CryptoKey
+    publicKey: CryptoKey
+  }
+
+  interface SubtleCrypto {
+    generateKey(
+      algorithm: string,
+      extractable: boolean,
+      keyUsages: string[],
+    ): Promise<CryptoKey | CryptoKeyPair>
+  }
+
+  interface Crypto {
+    readonly subtle: SubtleCrypto
+  }
+
+  const crypto: Crypto
 }
 
 type Equals<A, B> = [A] extends [B] ? ([B] extends [A] ? true : never) : never
 
-type KeyUsage =
-  'decrypt' | 'deriveBits' | 'deriveKey' | 'encrypt' | 'sign' | 'unwrapKey' | 'verify' | 'wrapKey'
-
 const _algorithm: Equals<jose.CryptoKey['algorithm'], { name: string }> = true
 const _extractable: Equals<jose.CryptoKey['extractable'], boolean> = true
-const _type: Equals<jose.CryptoKey['type'], 'private' | 'public' | 'secret'> = true
-const _usages: Equals<jose.CryptoKey['usages'], KeyUsage[]> = true
+const _type: Equals<jose.CryptoKey['type'], string> = true
+const _usages: Equals<jose.CryptoKey['usages'], string[]> = true
 
 // @ts-expect-error the fallback must not degrade to any
 const _notAny: jose.CryptoKey = 'definitely not a key'
+
+declare const token: string
+declare const key: CryptoKey
+
+jose.jwtVerify(token, key)


### PR DESCRIPTION
Keep fallback key types compatible with runtimes where crypto is declared with const or let. Add coverage for the jwtVerify regression.

Fixes: https://github.com/panva/jose/issues/886

@mattjohnsonpint please verify