### PR TITLE
fix: reject a JWE whose generated Key Management Parameters collide

### DIFF
--- a/src/jwe/general/encrypt.ts
+++ b/src/jwe/general/encrypt.ts
@@ -12,7 +12,7 @@ import { generateCek } from '../../lib/content_encryption.js'
 import { encryptKeyManagement } from '../../lib/key_management.js'
 import { encode as b64u } from '../../util/base64url.js'
 import { validateCritDuplicates } from '../../lib/options.js'
-import { checkEncryptHeaders, encryptJWE } from '../../lib/jwe_encrypt.js'
+import { checkDisjoint, checkEncryptHeaders, encryptJWE } from '../../lib/jwe_encrypt.js'
 import type { CheckedHeaders, EncryptInput } from '../../lib/jwe_encrypt.js'
 import { prepareKey } from '../../lib/key.js'
 import { jweAlgorithm } from '../../lib/jwe_algorithms.js'
@@ -307,7 +307,14 @@ export class GeneralEncrypt {
         keyManagementParameters,
       )
       target.encrypted_key = b64u(encryptedKey!)
-      if (unprotectedHeader || parameters) target.header = { ...unprotectedHeader, ...parameters }
+      if (unprotectedHeader || parameters) {
+        const header: types.JWEHeaderParameters = { ...unprotectedHeader, ...parameters }
+        // The generated Key Management Parameters join the JWE Per-Recipient Unprotected Header
+        // only after the headers were checked, so a name they collide with in another header would
+        // otherwise reach the result.
+        if (parameters) checkDisjoint(this.#protectedHeader, header, this.#unprotectedHeader)
+        target.header = header
+      }
     }
 
     return jwe as types.GeneralJWE

--- a/src/lib/jwe_encrypt.ts
+++ b/src/lib/jwe_encrypt.ts
@@ -32,6 +32,19 @@ export type CheckedHeaders = [
   encEntry: JWEEncryption,
 ]
 
+/** https://www.rfc-editor.org/rfc/rfc7516#section-7.2.1 */
+export function checkDisjoint(
+  protectedHeader: types.JWEHeaderParameters | undefined,
+  unprotectedHeader: types.JWEHeaderParameters | undefined,
+  sharedUnprotectedHeader: types.JWEHeaderParameters | undefined,
+): void {
+  if (!isDisjoint(protectedHeader, unprotectedHeader, sharedUnprotectedHeader)) {
+    throw new JWEInvalid(
+      'JWE Protected, JWE Shared Unprotected and JWE Per-Recipient Header Parameter names must be disjoint',
+    )
+  }
+}
+
 /**
  * Validates the headers of one recipient. Split out so a General JWE can validate every recipient
  * up front and then encrypt without validating any of them a second time.
@@ -39,11 +52,7 @@ export type CheckedHeaders = [
 export function checkEncryptHeaders(input: EncryptInput): CheckedHeaders {
   const [, protectedHeader, unprotectedHeader, sharedUnprotectedHeader, , , , , crit] = input
 
-  if (!isDisjoint(protectedHeader, unprotectedHeader, sharedUnprotectedHeader)) {
-    throw new JWEInvalid(
-      'JWE Protected, JWE Shared Unprotected and JWE Per-Recipient Header Parameter names must be disjoint',
-    )
-  }
+  checkDisjoint(protectedHeader, unprotectedHeader, sharedUnprotectedHeader)
 
   const joseHeader: types.JWEHeaderParameters = {
     ...protectedHeader,
@@ -121,6 +130,10 @@ export async function encryptJWE(
     } else {
       protectedHeader = protectedHeader ? { ...protectedHeader, ...parameters } : parameters
     }
+
+    // The generated Key Management Parameters join a header only after the input headers were
+    // checked, so a name they collide with in another header would otherwise reach the result.
+    checkDisjoint(protectedHeader, unprotectedHeader, sharedUnprotectedHeader)
   }
 
   let protectedHeaderS: string

--- a/test/jwe/flattened.encrypt.test.ts
+++ b/test/jwe/flattened.encrypt.test.ts
@@ -196,6 +196,33 @@ test('FlattenedEncrypt.prototype.encrypt JOSE header must be disjoint', async (t
   )
 })
 
+test('FlattenedEncrypt.prototype.encrypt generated Key Management Parameters must be disjoint', async (t) => {
+  // The generated "p2s" and "p2c" join the JWE Protected Header, so a "p2c" the caller put in
+  // another header would make the result violate RFC 7516 Section 7.2.1.
+  await t.throwsAsync(
+    new FlattenedEncrypt(t.context.plaintext)
+      .setProtectedHeader({ alg: 'PBES2-HS256+A128KW', enc: 'A128GCM' })
+      .setSharedUnprotectedHeader({ p2c: 4096 })
+      .encrypt(t.context.secret),
+    {
+      code: 'ERR_JWE_INVALID',
+      message:
+        'JWE Protected, JWE Shared Unprotected and JWE Per-Recipient Header Parameter names must be disjoint',
+    },
+  )
+  await t.throwsAsync(
+    new FlattenedEncrypt(t.context.plaintext)
+      .setProtectedHeader({ alg: 'A128GCMKW', enc: 'A128GCM' })
+      .setUnprotectedHeader({ tag: 'not-the-generated-one' })
+      .encrypt(t.context.secret),
+    {
+      code: 'ERR_JWE_INVALID',
+      message:
+        'JWE Protected, JWE Shared Unprotected and JWE Per-Recipient Header Parameter names must be disjoint',
+    },
+  )
+})
+
 test('FlattenedEncrypt.prototype.encrypt JOSE header have an alg', async (t) => {
   await t.throwsAsync(
     new FlattenedEncrypt(t.context.plaintext)

--- a/test/jwe/general.test.ts
+++ b/test/jwe/general.test.ts
@@ -316,3 +316,35 @@ test('single recipient ECDH-ES apu/apv are honoured', async (t) => {
   const { plaintext } = await generalDecrypt(jwe, privateKey)
   t.deepEqual(plaintext, t.context.plaintext)
 })
+
+test('General JWE generated Key Management Parameters must be disjoint', async (t) => {
+  // With more than one recipient the generated Key Management Parameters land in the JWE
+  // Per-Recipient Unprotected Header, so a name the caller already used in another header would
+  // make the emitted JWE violate RFC 7516 Section 7.2.1 - and generalDecrypt rejects such a JWE.
+  const message = {
+    code: 'ERR_JWE_INVALID',
+    message:
+      'JWE Protected, JWE Shared Unprotected and JWE Per-Recipient Header Parameter names must be disjoint',
+  }
+  await t.throwsAsync(
+    new GeneralEncrypt(t.context.plaintext)
+      .setProtectedHeader({ enc: 'A128GCM', p2c: 4096 })
+      .addRecipient(t.context.secret)
+      .setUnprotectedHeader({ alg: 'PBES2-HS256+A128KW' })
+      .addRecipient(t.context.secret2)
+      .setUnprotectedHeader({ alg: 'A128GCMKW' })
+      .encrypt(),
+    message,
+  )
+  await t.throwsAsync(
+    new GeneralEncrypt(t.context.plaintext)
+      .setProtectedHeader({ enc: 'A128GCM' })
+      .setSharedUnprotectedHeader({ p2c: 4096 })
+      .addRecipient(t.context.secret2)
+      .setUnprotectedHeader({ alg: 'A128GCMKW' })
+      .addRecipient(t.context.secret)
+      .setUnprotectedHeader({ alg: 'PBES2-HS256+A128KW' })
+      .encrypt(),
+    message,
+  )
+})


### PR DESCRIPTION
Per CONTRIBUTING I filed this as #894 first; I opened the PR alongside it because the fix is small, but close it without ceremony if you would rather take it yourself or keep the discussion on the issue.

Closes #894

## Problem

The JWE producing side checks that the JWE Protected, JWE Shared Unprotected and JWE Per-Recipient Unprotected Headers have disjoint parameter names, but only over the headers the caller supplied. The Key Management Parameters an `alg` generates (`epk`, `apu`, `apv`, `p2s`, `p2c`, `iv`, `tag`) are merged into one of those headers afterwards and disjointness is never re-established, so jose emits a JWE that violates [RFC 7516 Section 7.2.1](https://www.rfc-editor.org/rfc/rfc7516#section-7.2.1) ("The Header Parameter names in the three locations MUST be disjoint.") and that its own decrypt side then rejects.

```js
const jwe = await new jose.FlattenedEncrypt(new TextEncoder().encode('hello'))
  .setProtectedHeader({ alg: 'PBES2-HS256+A128KW', enc: 'A128GCM' })
  .setSharedUnprotectedHeader({ p2c: 4096 })
  .encrypt(new TextEncoder().encode('password'))

console.log(JSON.parse(Buffer.from(jwe.protected, 'base64url').toString()), jwe.unprotected)
await jose.flattenedDecrypt(jwe, new TextEncoder().encode('password'))
```

On 6.2.8 `encrypt()` resolves and the decrypt throws:

```
{ alg: 'PBES2-HS256+A128KW', enc: 'A128GCM', p2c: 2048, p2s: 'WBJPvuSakU0VdOgjMRwzKw' } { p2c: 4096 }

JWEInvalid: JWE Protected, JWE Unprotected Header, and JWE Per-Recipient Unprotected Header Parameter names must be disjoint
```

`CompactEncrypt` cannot hit this — it has only one header. The General serialization has the same hazard with more than one recipient, where the generated parameters land in the Per-Recipient Unprotected Header and collide with the Protected Header; only the affected recipient breaks. Covered by a test.

## Root cause

- `src/lib/jwe_encrypt.ts:42` — `checkEncryptHeaders()` runs `isDisjoint()` over the **input** headers.
- `src/lib/jwe_encrypt.ts:118-124` — `encryptJWE()` then merges the generated `parameters` into one of them; nothing re-checks.
- `src/jwe/general/encrypt.ts:310` — recipients after the first do the same merge on their own, bypassing `encryptJWE`.

## Fix

Lift the existing assertion into a `checkDisjoint()` helper (same `JWEInvalid`, same message — no new error type or string) and call it once more at the two sites where generated parameters join a header. It is skipped entirely when the alg generates none (`dir`, `RSA-OAEP*`, `A*KW`), and merging generated parameters into the *same* header the caller used is untouched, so the only inputs whose behaviour changes are those that previously produced a JWE `compactDecrypt`/`flattenedDecrypt`/`generalDecrypt` already refused — the failure just moves to encrypt time.

One design tension worth your call: the new check in the General loop runs during encryption rather than up front, unlike `checkEncryptHeaders`, whose comment says it exists so a General JWE can validate every recipient up front. The generated names are not knowable until key management has run. Happy to reshape it — e.g. rejecting caller-supplied Key Management Parameter names by `alg` before encrypting — if you prefer that shape.

## Tests

Two regression tests next to the existing `... JOSE header must be disjoint` ones, in `test/jwe/flattened.encrypt.test.ts` and `test/jwe/general.test.ts`. Both fail on `main` and pass with the fix; `npm test` goes 326 -> 328.

```
npm test                 328 passed
npm run tap:node         # pass 224 / # fail 0   (both CryptoKey and KeyObject passes)
npm run typecheck:tap    exit 0
npm run typecheck:types  exit 0
npm run typecheck:dist   OK
npm run check:subpaths   OK - 30 exports
npm run check:bundles    clean / exempt
npm run check:packaging  publint "All good!" + attw OK
npm run build:jsr        Success
npm run docs             docs/ unchanged
npm run format           no further changes
```

Local runs are Node-only; the other runtimes are covered by your CI.

## Notes

This is not a security issue and I am not claiming one — nothing is weakened and the affected tokens fail closed. The defect is that they are produced at all.

Separately, and deliberately left alone here: a Key Management Parameter placed in the *same* header jose writes the generated one into is silently overwritten (`setProtectedHeader({ alg: 'PBES2-HS256+A128KW', enc: 'A128GCM', p2c: 100000 })` emits `p2c: 2048`). No disjointness violation occurs there, so this PR does not touch it.
